### PR TITLE
Allow empty AWS_ENDPOINT env var

### DIFF
--- a/service-app/internal/aws/client.go
+++ b/service-app/internal/aws/client.go
@@ -33,9 +33,6 @@ type AwsClient struct {
 func NewAwsClient(ctx context.Context, cfg awsSdk.Config, appConfig *config.Config) (*AwsClient, error) {
 	// Use the same endpoint for all services
 	customEndpoint := appConfig.Aws.Endpoint
-	if customEndpoint == "" {
-		return nil, fmt.Errorf("AWS_ENDPOINT is not set")
-	}
 
 	smClient := secretsmanager.NewFromConfig(cfg, func(o *secretsmanager.Options) {
 		o.BaseEndpoint = &customEndpoint


### PR DESCRIPTION
# Purpose

The AWS_ENDPOINT env var allows us to overwrite the default AWS base URL for localstack. But our default behaviour should be not to set an endpoint at all and use whatever the default in the AWS SDK is.

This will help the task start in real AWS environments.

For SSM-20 #patch

## Approach

An empty/missing AWS_ENDPOINT will be handled as an empty string, and passing that to `Options.BaseEndpoint` is the behaviour that we want.

## Learning

I noticed that the envconfig package we're using has a `required` tag option that we're not using.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
  * N/A
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A
