### PR TITLE
Fix empty AWS endpoint

### DIFF
--- a/service-app/internal/aws/client.go
+++ b/service-app/internal/aws/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/ministryofjustice/opg-scanning/config"
 )
 
@@ -32,18 +33,21 @@ type AwsClient struct {
 // Initializes all required AWS service clients.
 func NewAwsClient(ctx context.Context, cfg awsSdk.Config, appConfig *config.Config) (*AwsClient, error) {
 	// Use the same endpoint for all services
-	customEndpoint := appConfig.Aws.Endpoint
+	var customEndpoint *string
+	if (appConfig.Aws.Endpoint != "") {
+		customEndpoint = aws.String(appConfig.Aws.Endpoint)
+	}
 
 	smClient := secretsmanager.NewFromConfig(cfg, func(o *secretsmanager.Options) {
-		o.BaseEndpoint = &customEndpoint
+		o.BaseEndpoint = customEndpoint
 	})
 
 	SsmClient := ssm.NewFromConfig(cfg, func(o *ssm.Options) {
-		o.BaseEndpoint = &customEndpoint
+		o.BaseEndpoint = customEndpoint
 	})
 
 	s3Client := s3.NewFromConfig(cfg, func(o *s3.Options) {
-		o.BaseEndpoint = &customEndpoint
+		o.BaseEndpoint = customEndpoint
 		o.UsePathStyle = appConfig.App.Environment == "local"
 	})
 

--- a/service-app/internal/logger/logger.go
+++ b/service-app/internal/logger/logger.go
@@ -14,9 +14,8 @@ type Logger struct {
 }
 
 func NewLogger(cfg *config.Config) *Logger {
-	slogLogger := telemetry.NewLogger("opg-scanning-service/getlist").With(
+	slogLogger := telemetry.NewLogger("opg-scanning-service").With(
 		slog.String("environment", cfg.App.Environment),
-		slog.String("service_name", "opg-scanning-service"),
 	)
 	return &Logger{
 		cfg:        cfg,


### PR DESCRIPTION
When an AWS endpoint is not provided, it should default to `nil`, not to `""`. We can do this by initialising as a null value and overwriting with `aws.String()` where needed.

Also, fix the logger `service_name` and only define it once.

#patch
