### PR TITLE
Use KMS encryption when saving objects

### DIFF
--- a/service-app/config/config.go
+++ b/service-app/config/config.go
@@ -26,10 +26,11 @@ type (
 	}
 
 	Aws struct {
-		JobsQueueURL    string `envconfig:"JOBQUEUE_SQS_QUEUE_URL" default:"000000000000/ddc.fifo"`
-		JobsQueueBucket string `envconfig:"JOBQUEUE_S3_BUCKET_NAME" default:"opg-backoffice-jobsqueue-local"`
-		Endpoint        string `envconfig:"AWS_ENDPOINT"`
-		Region          string `envconfig:"AWS_REGION" default:"eu-west-1"`
+		JobsQueueURL          string `envconfig:"JOBQUEUE_SQS_QUEUE_URL" default:"000000000000/ddc.fifo"`
+		JobsQueueBucket       string `envconfig:"JOBQUEUE_S3_BUCKET_NAME" default:"opg-backoffice-jobsqueue-local"`
+		JobsQueueBucketKmsKey string `envconfig:"JOBQUEUE_S3_ENCRYPTION_KEY" default:"alias/aws/s3"`
+		Endpoint              string `envconfig:"AWS_ENDPOINT"`
+		Region                string `envconfig:"AWS_REGION" default:"eu-west-1"`
 	}
 
 	Auth struct {

--- a/service-app/internal/aws/client.go
+++ b/service-app/internal/aws/client.go
@@ -34,7 +34,7 @@ type AwsClient struct {
 func NewAwsClient(ctx context.Context, cfg awsSdk.Config, appConfig *config.Config) (*AwsClient, error) {
 	// Use the same endpoint for all services
 	var customEndpoint *string
-	if (appConfig.Aws.Endpoint != "") {
+	if appConfig.Aws.Endpoint != "" {
 		customEndpoint = aws.String(appConfig.Aws.Endpoint)
 	}
 
@@ -101,7 +101,8 @@ func (a *AwsClient) PersistFormData(ctx context.Context, body io.Reader, docType
 		Bucket:               &bucketName,
 		Key:                  &fileName,
 		Body:                 body,
-		ServerSideEncryption: types.ServerSideEncryptionAes256,
+		ServerSideEncryption: types.ServerSideEncryptionAwsKms,
+		SSEKMSKeyId:          &a.config.Aws.JobsQueueBucketKmsKey,
 	}
 
 	// Upload the file to S3


### PR DESCRIPTION
The S3 bucket is protected by a CMK, so we need to specify KMS encryption and use the ID of the KMS key (passed in by an env var).

For SSM-15 #patch
