### PR TITLE
feat/SSM-31: added context with timeout to avoid hanging requests.

### DIFF
--- a/service-app/internal/api/handler.go
+++ b/service-app/internal/api/handler.go
@@ -129,7 +129,9 @@ func (c *IndexController) IngestHandler(w http.ResponseWriter, r *http.Request) 
 	// Create a new client and prepare to attach documents
 	client := NewClient(c.httpMiddleware)
 	service := NewService(client, parsedBaseXml)
-	scannedCaseResponse, err := service.CreateCaseStub(r.Context())
+	ctx, cancel := context.WithTimeout(r.Context(), time.Duration(c.config.HTTP.Timeout)*time.Second)
+	defer cancel()
+	scannedCaseResponse, err := service.CreateCaseStub(ctx)
 	if err != nil {
 		c.respondWithError(w, http.StatusInternalServerError, "Failed to create case stub in Sirius", err)
 		return


### PR DESCRIPTION
# Purpose

Change is to fix the timeout issue in the IngestHandler function within handler.go.

## Approach

To fix the timeout issue, I added a `context.WithTimeout` call to set a timeout duration for the HTTP call to create a stub case in Sirius. This ensures that the HTTP call does not wait indefinitely for a response, and instead returns an error if the response takes longer than the specified timeout duration.

Additionally, added the `cancel()` function to ensure that the context is cancelled when the function returns, but not before the `CreateCaseStub` call has completed.

## Learning

Check my context usages properly!

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added relevant logging with appropriate levels to my code
- [x] I have updated documentation where relevant
- [x] I have added tests to prove my work