### PR TITLE
Set decodedXML a level higher

### DIFF
--- a/service-app/internal/api/service.go
+++ b/service-app/internal/api/service.go
@@ -33,15 +33,14 @@ func NewService(client *Client, set *types.BaseSet) *Service {
 func (s *Service) AttachDocuments(ctx context.Context, caseResponse *types.ScannedCaseResponse) (*types.ScannedDocumentResponse, []byte, error) {
 	var documentSubType string
 
-	decodedXML := []byte(nil)
+	// Decode the base64-encoded XML
+	decodedXML, err := base64.StdEncoding.DecodeString(s.originalDoc.EmbeddedXML)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to decode base64-encoded XML: %w", err)
+	}
 
 	// Check for Correspondence or SupCorrespondence and extract SubType
 	if util.Contains([]string{"Correspondence", "SupCorrespondence"}, s.originalDoc.Type) {
-		// Decode the base64-encoded XML
-		decodedXML, err := base64.StdEncoding.DecodeString(s.originalDoc.EmbeddedXML)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to decode base64-encoded XML: %w", err)
-		}
 		// Parse the XML
 		correspDoc, err := corresp_parser.Parse([]byte(decodedXML))
 		if err != nil {

--- a/service-app/internal/api/service_documents_test.go
+++ b/service-app/internal/api/service_documents_test.go
@@ -77,11 +77,12 @@ func TestAttachDocument_Correspondence(t *testing.T) {
 		mock.Anything).Return(mockResponseBytes, nil)
 
 	ctx := context.Background()
-	response, _, err := service.AttachDocuments(ctx, caseResponse)
+	response, decodedXML, err := service.AttachDocuments(ctx, caseResponse)
 	if err != nil {
 		t.Fatalf("AttachDocuments returned error: %v", err)
 	}
 	assert.NotNil(t, response, "Expected non-nil response")
 	assert.Equal(t, mockResponse, response, "Expected response to match mock response")
+	assert.Equal(t, xmlStringData, decodedXML)
 	mockHttpClient.AssertExpectations(t)
 }


### PR DESCRIPTION
To ensure it's returned for all documents

Fixes SSM-36 #patch
