### PR TITLE
feat/SSM-44: added validation logic to persist form data and expanded…

### DIFF
--- a/service-app/internal/aws/client_test.go
+++ b/service-app/internal/aws/client_test.go
@@ -32,12 +32,18 @@ func TestPersistFormData_LocalStack(t *testing.T) {
 	awsClient, err := NewAwsClient(ctx, cfg, appConfig)
 	assert.NoError(t, err, "Failed to load AWS client")
 
+	// Test PersistFormData valid
 	docType := "TestDoc"
-	body := bytes.NewReader([]byte("test data"))
-
+	body := bytes.NewReader([]byte("<?xml version=\"1.0\" encoding=\"UTF-8\"?><test>test</test>"))
 	fileName, err := awsClient.PersistFormData(ctx, body, docType)
 	assert.NoError(t, err, "PersistFormData should not return an error")
 	assert.Contains(t, fileName, "FORM_DDC_", "Expected file name to start with 'FORM_DDC_'")
+
+	// Test PersistFormData invalid
+	docType = "TestDoc"
+	body = bytes.NewReader([]byte("invalid xml"))
+	_, err = awsClient.PersistFormData(ctx, body, docType)
+	assert.Error(t, err, "PersistFormData should return an error for invalid XML")
 
 	currentTime := time.Now().Format("20060102150405")
 	expectedKey := fmt.Sprintf("FORM_DDC_%s_%s.xml", currentTime, docType)

--- a/service-app/internal/util/common.go
+++ b/service-app/internal/util/common.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"encoding/xml"
 	"fmt"
 	"log"
 	"os"
@@ -85,4 +86,12 @@ func PhpSerialize(data map[string]interface{}) string {
 
 	sb.WriteString("}")
 	return sb.String()
+}
+
+func IsValidXML(data []byte) error {
+	var v interface{}
+	if err := xml.Unmarshal(data, &v); err != nil {
+		return fmt.Errorf("xml unmarshal error: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
… test coverage.

# Purpose

Need to expand on validation and test coverage when inserting documents in S3 to ensure downstream its not effected by invalid XML.

Fixes SSM-44

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
