### PR TITLE
feat/SSM-27: added lpa120 document type structs.

### DIFF
--- a/service-app/internal/api/handler.go
+++ b/service-app/internal/api/handler.go
@@ -269,7 +269,7 @@ func (c *IndexController) validateAndSanitizeXML(bodyStr string) (*types.BaseSet
 }
 
 func (c *IndexController) processAndPersist(ctx context.Context, decodedXML []byte, originalDoc *types.BaseDocument) (fileName string, err error) {
-	// Persist the XML
+	// Persist the decoded XML data in its original form as represented in the origin request.
 	xmlReader := bytes.NewReader(decodedXML)
 	fileName, awsErr := c.AwsClient.PersistFormData(ctx, xmlReader, originalDoc.Type)
 	if awsErr != nil {

--- a/service-app/internal/api/service.go
+++ b/service-app/internal/api/service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ministryofjustice/opg-scanning/internal/parser/corresp_parser"
 	"github.com/ministryofjustice/opg-scanning/internal/types"
+	"github.com/ministryofjustice/opg-scanning/internal/types/corresp_types"
 	"github.com/ministryofjustice/opg-scanning/internal/util"
 )
 
@@ -42,11 +43,15 @@ func (s *Service) AttachDocuments(ctx context.Context, caseResponse *types.Scann
 	// Check for Correspondence or SupCorrespondence and extract SubType
 	if util.Contains([]string{"Correspondence", "SupCorrespondence"}, s.originalDoc.Type) {
 		// Parse the XML
-		correspDoc, err := corresp_parser.Parse([]byte(decodedXML))
+		correspInterface, err := corresp_parser.Parse([]byte(decodedXML))
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to parse correspondence for document %s: %w", s.originalDoc.Type, err)
 		}
-		documentSubType = correspDoc.SubType
+		corresp, ok := correspInterface.(*corresp_types.Correspondence)
+		if !ok {
+			return nil, nil, fmt.Errorf("failed to cast correspInterface to corresp_types.Correspondence")
+		}
+		documentSubType = corresp.SubType
 	}
 
 	// Prepare the request payload

--- a/service-app/internal/constants/document_types.go
+++ b/service-app/internal/constants/document_types.go
@@ -7,9 +7,11 @@ const (
 	DocumentTypeLPAPW   = "LPA-PW"
 	DocumentTypeLPA114  = "LPA114"
 	DocumentTypeLPA117  = "LPA117"
+	DocumentTypeLPA120  = "LPA120"
 	DocumentTypeLP1F    = "LP1F"
 	DocumentTypeLP1H    = "LP1H"
 	DocumentTypeLP2     = "LP2"
+	DocumentTypeLPC     = "LPC"
 	DocumentCorresp     = "Correspondence"
 )
 
@@ -27,6 +29,8 @@ var (
 		DocumentTypeLP1F,
 		DocumentTypeLP1H,
 		DocumentCorresp,
+		DocumentTypeLPC,
+		DocumentTypeLPA120,
 	}
 
 	LPATypeDocuments = []string{

--- a/service-app/internal/factory/document_component.go
+++ b/service-app/internal/factory/document_component.go
@@ -18,47 +18,37 @@ type Component struct {
 	Sanitizer parser.CommonSanitizer
 }
 
+// Stores the mapping of document types to their respective components.
+var componentRegistry = map[string]Component{
+	"LP1H": {
+		Parser:    lp1h_parser.Parse,
+		Validator: lp1h_parser.NewValidator(),
+		Sanitizer: lp1h_parser.NewSanitizer(),
+	},
+	"LP1F": {
+		Parser:    lp1f_parser.Parse,
+		Validator: lp1f_parser.NewValidator(),
+		Sanitizer: lp1f_parser.NewSanitizer(),
+	},
+	"Correspondence": {
+		Parser:    corresp_parser.Parse,
+		Validator: corresp_parser.NewValidator(),
+		Sanitizer: corresp_parser.NewSanitizer(),
+	},
+	"LPC": {
+		Parser:    lpc_parser.Parse,
+		Validator: lpc_parser.NewValidator(),
+		Sanitizer: lpc_parser.NewSanitizer(),
+	},
+	"LPA120": {
+		Parser: lpa120_parser.Parse,
+	},
+}
+
+// Returns the component for the specified document type.
 func GetComponent(docType string) (Component, error) {
-	switch docType {
-	case "LP1H":
-		return Component{
-			Parser: func(data []byte) (interface{}, error) {
-				return lp1h_parser.Parse(data)
-			},
-			Validator: lp1h_parser.NewValidator(),
-			Sanitizer: lp1h_parser.NewSanitizer(),
-		}, nil
-	case "LP1F":
-		return Component{
-			Parser: func(data []byte) (interface{}, error) {
-				return lp1f_parser.Parse(data)
-			},
-			Validator: lp1f_parser.NewValidator(),
-			Sanitizer: lp1f_parser.NewSanitizer(),
-		}, nil
-	case "Correspondence":
-		return Component{
-			Parser: func(data []byte) (interface{}, error) {
-				return corresp_parser.Parse(data)
-			},
-			Validator: corresp_parser.NewValidator(),
-			Sanitizer: corresp_parser.NewSanitizer(),
-		}, nil
-	case "LPC":
-		return Component{
-			Parser: func(data []byte) (interface{}, error) {
-				return lpc_parser.Parse(data)
-			},
-			Validator: lpc_parser.NewValidator(),
-			Sanitizer: lpc_parser.NewSanitizer(),
-		}, nil
-	case "LPA120":
-		return Component{
-			Parser: func(data []byte) (interface{}, error) {
-				return lpa120_parser.Parse(data)
-			},
-		}, nil
-	default:
-		return Component{}, fmt.Errorf("unsupported docType: %s", docType)
+	if component, exists := componentRegistry[docType]; exists {
+		return component, nil
 	}
+	return Component{}, fmt.Errorf("unsupported docType: %s", docType)
 }

--- a/service-app/internal/factory/document_component.go
+++ b/service-app/internal/factory/document_component.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ministryofjustice/opg-scanning/internal/parser/corresp_parser"
 	"github.com/ministryofjustice/opg-scanning/internal/parser/lp1f_parser"
 	"github.com/ministryofjustice/opg-scanning/internal/parser/lp1h_parser"
+	"github.com/ministryofjustice/opg-scanning/internal/parser/lpa120_parser"
 	"github.com/ministryofjustice/opg-scanning/internal/parser/lpc_parser"
 )
 
@@ -50,6 +51,12 @@ func GetComponent(docType string) (Component, error) {
 			},
 			Validator: lpc_parser.NewValidator(),
 			Sanitizer: lpc_parser.NewSanitizer(),
+		}, nil
+	case "LPA120":
+		return Component{
+			Parser: func(data []byte) (interface{}, error) {
+				return lpa120_parser.Parse(data)
+			},
 		}, nil
 	default:
 		return Component{}, fmt.Errorf("unsupported docType: %s", docType)

--- a/service-app/internal/factory/document_factory_test.go
+++ b/service-app/internal/factory/document_factory_test.go
@@ -8,21 +8,68 @@ import (
 	"github.com/ministryofjustice/opg-scanning/config"
 	"github.com/ministryofjustice/opg-scanning/internal/logger"
 	"github.com/ministryofjustice/opg-scanning/internal/types"
+	"github.com/ministryofjustice/opg-scanning/internal/types/corresp_types"
 	"github.com/ministryofjustice/opg-scanning/internal/types/lp1f_types"
+	"github.com/ministryofjustice/opg-scanning/internal/types/lp1h_types"
+	"github.com/ministryofjustice/opg-scanning/internal/types/lpc_types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestProcessDocument_LP1F(t *testing.T) {
+	processedDoc := prepareDocument(t, "LP1F", "LP1F-valid")
+
+	lp1fDoc, ok := processedDoc.(*lp1f_types.LP1FDocument)
+	require.True(t, ok, "Expected processedDoc to be of type *lp1f_types.LP1FDocument")
+
+	assert.Equal(t, "Charles", lp1fDoc.Page1.Section1.FirstName, "FirstName mismatch")
+	assert.Equal(t, "Anderson", lp1fDoc.Page1.Section1.LastName, "LastName mismatch")
+}
+
+func TestProcessDocument_LP1H(t *testing.T) {
+	processedDoc := prepareDocument(t, "LP1H", "LP1H-valid")
+
+	lp1hDoc, ok := processedDoc.(*lp1h_types.LP1HDocument)
+	require.True(t, ok, "Expected processedDoc to be of type *lp1f_types.LP1HDocument")
+
+	assert.Equal(t, "John", lp1hDoc.Page1.Section1.FirstName, "FirstName mismatch")
+	assert.Equal(t, "Doe", lp1hDoc.Page1.Section1.LastName, "LastName mismatch")
+}
+
+func TestProcessDocument_Correspondence(t *testing.T) {
+	processedDoc := prepareDocument(t, "Correspondence", "Correspondence-valid")
+
+	corresp, ok := processedDoc.(*corresp_types.Correspondence)
+	require.True(t, ok, "Expected processedDoc to be of type *corresp_types.Correspondence")
+
+	assert.Equal(t, "Legal", corresp.SubType, "SubType mismatch")
+	assert.Equal(t, "12345", corresp.CaseNumber[0], "CaseNumber mismatch")
+}
+
+func TestProcessDocument_LPC(t *testing.T) {
+	processedDoc := prepareDocument(t, "LPC", "LPC-valid")
+
+	lpc, ok := processedDoc.(*lpc_types.LPCDocument)
+	require.True(t, ok, "Expected processedDoc to be of type *corresp_types.Correspondence")
+
+	assert.Equal(t, "Jack", lpc.Page1[0].ContinuationSheet1.Attorneys[0].FirstName, "FirstName mismatch")
+	assert.Equal(t, "Jones", lpc.Page1[0].ContinuationSheet1.Attorneys[0].LastName, "LastName mismatch")
+}
+
+func TestProcessDocument_LPA120(t *testing.T) {
+	// TODO Add test
+}
+
+func prepareDocument(t *testing.T, docType string, fileName string) interface{} {
 	// Load the sample XML from the xml directory
-	encodedXML := loadXMLFile(t, "../../xml/LP1F-valid.xml")
+	encodedXML := loadXMLFile(t, "../../xml/"+fileName+".xml")
 	if encodedXML == "" {
 		t.Fatal("failed to load sample XML")
 	}
 
 	// Create a base document with the loaded XML
 	doc := &types.BaseDocument{
-		Type:        "LP1F",
+		Type:        docType,
 		Encoding:    "base64",
 		NoPages:     1,
 		EmbeddedXML: encodedXML,
@@ -41,11 +88,7 @@ func TestProcessDocument_LP1F(t *testing.T) {
 	processedDoc, err := processor.Process()
 	require.NoError(t, err, "Document processing failed")
 
-	lp1fDoc, ok := processedDoc.(*lp1f_types.LP1FDocument)
-	require.True(t, ok, "Expected processedDoc to be of type *lp1f_types.LP1FDocument")
-
-	assert.Equal(t, "Charles", lp1fDoc.Page1.Section1.FirstName, "FirstName mismatch")
-	assert.Equal(t, "Anderson", lp1fDoc.Page1.Section1.LastName, "LastName mismatch")
+	return processedDoc
 }
 
 func loadXMLFile(t *testing.T, filepath string) string {

--- a/service-app/internal/factory/document_factory_test.go
+++ b/service-app/internal/factory/document_factory_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ministryofjustice/opg-scanning/internal/types/corresp_types"
 	"github.com/ministryofjustice/opg-scanning/internal/types/lp1f_types"
 	"github.com/ministryofjustice/opg-scanning/internal/types/lp1h_types"
+	"github.com/ministryofjustice/opg-scanning/internal/types/lpa120_types"
 	"github.com/ministryofjustice/opg-scanning/internal/types/lpc_types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,14 +51,19 @@ func TestProcessDocument_LPC(t *testing.T) {
 	processedDoc := prepareDocument(t, "LPC", "LPC-valid")
 
 	lpc, ok := processedDoc.(*lpc_types.LPCDocument)
-	require.True(t, ok, "Expected processedDoc to be of type *corresp_types.Correspondence")
+	require.True(t, ok, "Expected processedDoc to be of type *lpc_types.LPCDocument")
 
 	assert.Equal(t, "Jack", lpc.Page1[0].ContinuationSheet1.Attorneys[0].FirstName, "FirstName mismatch")
 	assert.Equal(t, "Jones", lpc.Page1[0].ContinuationSheet1.Attorneys[0].LastName, "LastName mismatch")
 }
 
 func TestProcessDocument_LPA120(t *testing.T) {
-	// TODO Add test
+	processedDoc := prepareDocument(t, "LPA120", "LPA120-valid")
+
+	lpa120, ok := processedDoc.(*lpa120_types.LPA120Document)
+	require.True(t, ok, "Expected processedDoc to be of type *corresp_types.Correspondence")
+
+	assert.Equal(t, "John Doe", lpa120.Page3.Section1.FullName, "FullName mismatch")
 }
 
 func prepareDocument(t *testing.T, docType string, fileName string) interface{} {

--- a/service-app/internal/factory/document_processor.go
+++ b/service-app/internal/factory/document_processor.go
@@ -58,6 +58,11 @@ func NewDocumentProcessor(data *types.BaseDocument, docType, format string, regi
 
 // Process validates and sanitizes the document.
 func (p *DocumentProcessor) Process() (interface{}, error) {
+	// If the document type doesn't declare a validator or sanitizer, skip.
+	if p.validator == nil || p.sanitizer == nil {
+		return p.doc, nil
+	}
+
 	// Validate the document
 	p.validator.Setup(p.doc)
 	if err := p.validator.Validate(); err != nil {

--- a/service-app/internal/factory/document_processor.go
+++ b/service-app/internal/factory/document_processor.go
@@ -59,17 +59,18 @@ func NewDocumentProcessor(data *types.BaseDocument, docType, format string, regi
 }
 
 // Process validates and sanitizes the document.
-func (p *DocumentProcessor) Process() (interface{}, error) {
+func (p *DocumentProcessor) Process(ctx context.Context) (interface{}, error) {
 	// If the document type doesn't declare a validator or sanitizer, skip.
 	if p.validator == nil || p.sanitizer == nil {
 		return p.doc, nil
 	}
 
 	// Validate the document
+	traceID, _ := ctx.Value(constants.TraceIDKey).(string)
 	p.validator.Setup(p.doc)
 	if err := p.validator.Validate(); err != nil {
 		p.logger.Error("Validation failed: "+err.Error(), map[string]interface{}{
-			"trace_id": ctx.Value(constants.TraceIDKey).(string),
+			"trace_id": traceID,
 		})
 	}
 

--- a/service-app/internal/parser/corresp_parser/corresp_parser.go
+++ b/service-app/internal/parser/corresp_parser/corresp_parser.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ministryofjustice/opg-scanning/internal/types/corresp_types"
 )
 
-func Parse(data []byte) (*corresp_types.Correspondence, error) {
+func Parse(data []byte) (interface{}, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("correspondence data is empty")
 	}

--- a/service-app/internal/parser/corresp_parser/corresp_parser.go
+++ b/service-app/internal/parser/corresp_parser/corresp_parser.go
@@ -1,26 +1,11 @@
 package corresp_parser
 
 import (
-	"encoding/xml"
-	"fmt"
-
 	"github.com/ministryofjustice/opg-scanning/internal/parser"
 	"github.com/ministryofjustice/opg-scanning/internal/types/corresp_types"
 )
 
 func Parse(data []byte) (interface{}, error) {
-	if len(data) == 0 {
-		return nil, fmt.Errorf("correspondence data is empty")
-	}
-
 	doc := &corresp_types.Correspondence{}
-	if err := xml.Unmarshal(data, doc); err != nil {
-		return nil, err
-	}
-	// Validate required fields based on struct tags
-	if err := parser.ValidateStruct(doc); err != nil {
-		return nil, err
-	}
-
-	return doc, nil
+	return parser.DocumentParser(data, doc)
 }

--- a/service-app/internal/parser/lpa120_parser/lpa120_parser.go
+++ b/service-app/internal/parser/lpa120_parser/lpa120_parser.go
@@ -1,0 +1,11 @@
+package lpa120_parser
+
+import (
+	"github.com/ministryofjustice/opg-scanning/internal/parser"
+	"github.com/ministryofjustice/opg-scanning/internal/types/lpa120_types"
+)
+
+func Parse(data []byte) (interface{}, error) {
+	doc := &lpa120_types.LPA120Document{}
+	return parser.DocumentParser(data, doc)
+}

--- a/service-app/internal/types/lpa120/lpa120_document.go
+++ b/service-app/internal/types/lpa120/lpa120_document.go
@@ -1,0 +1,79 @@
+package lpa120_document
+
+import (
+	"encoding/xml"
+
+	"github.com/ministryofjustice/opg-scanning/internal/types"
+	"github.com/ministryofjustice/opg-scanning/internal/types/lp1f_types"
+)
+
+type LPA120Document struct {
+	XMLName   xml.Name `xml:"LPA120"`
+	Page1     Page     `xml:"Page1"`
+	Page2     Page     `xml:"Page2"`
+	Page3     Page3    `xml:"Page3"`
+	Page4     Page4    `xml:"Page4"`
+	InfoPages []Page   `xml:"InfoPage,omitempty"`
+}
+
+type Page struct {
+	types.BasePage
+}
+
+type Page3 struct {
+	Section1 Section1 `xml:"Section1"`
+	Section2 Section2 `xml:"Section2"`
+	types.BasePage
+}
+
+type Section1 struct {
+	FullName                string             `xml:"FullName"`
+	Address                 lp1f_types.Address `xml:"Address"`
+	CaseReference           string             `xml:"CaseReference"`
+	LPAApplicationFee       bool               `xml:"LPAApplicationFee"`
+	EPAApplicationFee       bool               `xml:"EPAApplicationFee"`
+	RepeatLPAApplicationFee bool               `xml:"RepeatLPAApplicationFee"`
+	LPAHealthWelfare        bool               `xml:"LPAHealthWelfare"`
+	LPAPropertyFinance      bool               `xml:"LPAPropertyFinance"`
+	EPA                     bool               `xml:"EPA"`
+}
+
+type Section2 struct {
+	Relationship Relationship          `xml:"Relationship"`
+	Salutation   lp1f_types.Salutation `xml:"Salutation"`
+	FirstName    string                `xml:"FirstName"`
+	LastName     string                `xml:"LastName"`
+	Address      lp1f_types.Address
+	Telephone    string `xml:"Telephone"`
+	Mobile       string `xml:"Mobile"`
+	Email        string `xml:"Email"`
+	FeePaidTo    string `xml:"FeePaidTo"`
+}
+
+type Page4 struct {
+	Section3 Section3 `xml:"Section3"`
+	Section4 Section4 `xml:"Section4"`
+	Section5 Section5 `xml:"Section5"`
+	types.BasePage
+}
+
+type Section3 struct {
+	DonorReceivesBenefits lp1f_types.YesOrNo `xml:"DonorReceivesBenefits"`
+	DonorAwardedInjuries  lp1f_types.YesOrNo `xml:"DonorAwardedInjuries"`
+}
+
+type Section4 struct {
+	DonorOver12000               lp1f_types.YesOrNo `xml:"DonorOver12000"`
+	DonorReceivesUniversalCredit lp1f_types.YesOrNo `xml:"DonorReceivesUniversalCredit"`
+}
+
+type Section5 struct {
+	Declaration lp1f_types.Declaration `xml:"Declaration"`
+}
+
+type Relationship struct {
+	Donor       bool   `xml:"Donor"`
+	Attorney    bool   `xml:"Attorney"`
+	Other       bool   `xml:"Other"`
+	OtherDetail string `xml:"OtherDetail,omitempty"`
+}

--- a/service-app/internal/types/lpa120_types/lpa120_document.go
+++ b/service-app/internal/types/lpa120_types/lpa120_document.go
@@ -1,4 +1,4 @@
-package lpa120_document
+package lpa120_types
 
 import (
 	"encoding/xml"

--- a/service-app/xml/LPA120-valid.xml
+++ b/service-app/xml/LPA120-valid.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LPA120>
+  <Page1>
+    <BURN>DummyBurn1</BURN>
+    <PhysicalPage>1</PhysicalPage>
+  </Page1>
+  <Page2>
+    <BURN>DummyBurn2</BURN>
+    <PhysicalPage>2</PhysicalPage>
+  </Page2>
+  <Page3>
+    <Section1>
+      <FullName>John Doe</FullName>
+      <Address>
+        <Address1>123 Fake Street</Address1>
+        <Address2>Suite 100</Address2>
+        <Address3>Building A</Address3>
+        <TownCity>Faketown</TownCity>
+        <County>Fakeshire</County>
+        <Postcode>FA1 2KE</Postcode>
+      </Address>
+      <CaseReference>CR123456</CaseReference>
+      <LPAApplicationFee>true</LPAApplicationFee>
+      <EPAApplicationFee>false</EPAApplicationFee>
+      <RepeatLPAApplicationFee>false</RepeatLPAApplicationFee>
+      <LPAHealthWelfare>true</LPAHealthWelfare>
+      <LPAPropertyFinance>false</LPAPropertyFinance>
+      <EPA>true</EPA>
+    </Section1>
+    <Section2>
+      <Relationship>
+        <Donor>true</Donor>
+        <Attorney>false</Attorney>
+        <Other>false</Other>
+        <OtherDetail>N/A</OtherDetail>
+      </Relationship>
+      <Salutation>
+        <Mr>true</Mr>
+        <Mrs>false</Mrs>
+        <Ms>false</Ms>
+        <Miss>false</Miss>
+        <Other>false</Other>
+        <OtherName>N/A</OtherName>
+      </Salutation>
+      <FirstName>Jane</FirstName>
+      <LastName>Smith</LastName>
+      <Address>
+        <Address1>456 Sample Road</Address1>
+        <Address2>Floor 2</Address2>
+        <Address3>Unit 5</Address3>
+        <TownCity>Sampleville</TownCity>
+        <County>Samplestate</County>
+        <Postcode>SM4 5PL</Postcode>
+      </Address>
+      <Telephone>0123456789</Telephone>
+      <Mobile>0987654321</Mobile>
+      <Email>jane.smith@example.com</Email>
+      <FeePaidTo>Example Recipient</FeePaidTo>
+    </Section2>
+    <BURN>DummyBurn3</BURN>
+    <PhysicalPage>3</PhysicalPage>
+  </Page3>
+  <Page4>
+    <Section3>
+      <DonorReceivesBenefits>
+        <YesorNo>
+          <Yes>true</Yes>
+          <No>false</No>
+        </YesorNo>
+      </DonorReceivesBenefits>
+      <DonorAwardedInjuries>
+        <YesorNo>
+          <Yes>false</Yes>
+          <No>true</No>
+        </YesorNo>
+      </DonorAwardedInjuries>
+    </Section3>
+    <Section4>
+      <DonorOver12000>
+        <YesorNo>
+          <Yes>false</Yes>
+          <No>true</No>
+        </YesorNo>
+      </DonorOver12000>
+      <DonorReceivesUniversalCredit>
+        <YesorNo>
+          <Yes>true</Yes>
+          <No>false</No>
+        </YesorNo>
+      </DonorReceivesUniversalCredit>
+    </Section4>
+    <Section5>
+      <Declaration>
+        <Signed>true</Signed>
+        <Date>2025-02-17</Date>
+      </Declaration>
+    </Section5>
+    <BURN>DummyBurn4</BURN>
+    <PhysicalPage>4</PhysicalPage>
+  </Page4>
+  <InfoPage>
+    <BURN>DummyBurnInfo</BURN>
+    <PhysicalPage>5</PhysicalPage>
+  </InfoPage>
+</LPA120>

--- a/service-app/xml/LPA120-valid.xml
+++ b/service-app/xml/LPA120-valid.xml
@@ -25,7 +25,7 @@
       <RepeatLPAApplicationFee>false</RepeatLPAApplicationFee>
       <LPAHealthWelfare>true</LPAHealthWelfare>
       <LPAPropertyFinance>false</LPAPropertyFinance>
-      <EPA>true</EPA>
+      <EPA>false</EPA>
     </Section1>
     <Section2>
       <Relationship>

--- a/service-app/xml/LPC-valid.xml
+++ b/service-app/xml/LPC-valid.xml
@@ -7,8 +7,8 @@
                 <ReplacementAttorney>false</ReplacementAttorney>
                 <PersonToNotify>false</PersonToNotify>
                 <Title>Mr</Title>
-                <FirstName>John</FirstName>
-                <LastName>Doe</LastName>
+                <FirstName>Jack</FirstName>
+                <LastName>Jones</LastName>
                 <DOB>1970-01-01</DOB>
                 <Address>
                     <Address1>1 Example Road</Address1>


### PR DESCRIPTION
# Purpose

Handle LPA120 (reduced Fees) form

Fixes SSM-27

## Approach

Integrated and reused existing go structs to support LPA120 XSD.

## Learning

Due to the volume of form types, slightly optimised switch-case to use mapper instead with a getter function which returns the correct instances for parser, validation, and sanitisation.

It appears that the document ingestion at the factory level does not fully support all XML document types. Additional tests have been added for each valid document type in the XML directory.

While adding the additional tests, I noticed that "LPC" document type was missing in 
`SupprotedDocumentTypes = []string{
		DocumentTypeLP1F,
		DocumentTypeLP1H,
		DocumentCorresp,
	}`

This implies an underlying bug which has been resolved.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
