### PR TITLE
Add office payment fields to LP1F/H XSD

### DIFF
--- a/service-app/xsd/LP1F.xsd
+++ b/service-app/xsd/LP1F.xsd
@@ -382,6 +382,9 @@
                                         <xs:element name="CaseNumber" type="xs:string"/>
                                         <xs:element name="OnlineLPA" type="xs:boolean" minOccurs="0"/>
                                         <xs:element name="OnlineLPAID" type="xs:string" minOccurs="0"/>
+                                        <xs:element name="OfficePaymentReference" type="xs:string" minOccurs="0"/>
+                                        <xs:element name="OfficePaymentDate" type="xs:string" minOccurs="0"/>
+                                        <xs:element name="OfficePaymentAmount" type="xs:string" minOccurs="0"/>
                                     </xs:sequence>
                                 </xs:complexType>
                             </xs:element>

--- a/service-app/xsd/LP1H.xsd
+++ b/service-app/xsd/LP1H.xsd
@@ -380,6 +380,9 @@
                                         <xs:element name="CaseNumber" type="xs:string"/>
                                         <xs:element name="OnlineLPA" type="xs:boolean" minOccurs="0"/>
                                         <xs:element name="OnlineLPAID" type="xs:string" minOccurs="0"/>
+                                        <xs:element name="OfficePaymentReference" type="xs:string" minOccurs="0"/>
+                                        <xs:element name="OfficePaymentDate" type="xs:string" minOccurs="0"/>
+                                        <xs:element name="OfficePaymentAmount" type="xs:string" minOccurs="0"/>
                                     </xs:sequence>
                                 </xs:complexType>
                             </xs:element>


### PR DESCRIPTION
# Purpose

We want to extract the payment reference, date and amount from the form so we can trace cheque payments in the future.

For SSM-62 #minor

## Approach

Aligning from ministryofjustice/opg-sirius#10980

## Learning

`xs:sequence` seems to validate weirdly in PHP, but that isn't a problem for now.
