### PR TITLE
POC for accepting separate documents

### DIFF
--- a/service-app/internal/constants/document_types.go
+++ b/service-app/internal/constants/document_types.go
@@ -48,33 +48,13 @@ var (
 		DocumentTypeEPA,
 	}
 
-	Instruments = []string{
-		DocumentTypeEPA,
-		DocumentTypeLPAPW,
-		DocumentTypeLPAPA,
-		DocumentTypeLPA114,
-		DocumentTypeLPA117,
-		DocumentTypeLP1F,
-		DocumentTypeLP1H,
-	}
-
-	Applications = []string{
+	NewCaseDocuments = []string{
 		DocumentTypeEP2PG,
 		DocumentTypeLPA002,
 		DocumentTypeLP0002R,
 		DocumentTypeLP2,
-	}
-
-	CourtOrderDocuments = []string{
-		DocumentTypeCOPORD,
-	}
-
-	StandaloneInstruments = []string{
 		DocumentTypeLP1F,
 		DocumentTypeLP1H,
-	}
-
-	ExemptApplications = []string{
-		DocumentTypeLP0002R,
+		DocumentTypeCOPORD,
 	}
 )

--- a/service-app/internal/constants/document_types.go
+++ b/service-app/internal/constants/document_types.go
@@ -27,6 +27,13 @@ var (
 		DocumentTypeLP1F,
 		DocumentTypeLP1H,
 		DocumentCorresp,
+		DocumentTypeLPA002,
+		DocumentTypeLPAPA,
+		DocumentTypeLPAPW,
+		DocumentTypeLPA114,
+		DocumentTypeLPA117,
+		DocumentTypeEP2PG,
+		DocumentTypeLP2,
 	}
 
 	LPATypeDocuments = []string{

--- a/service-app/internal/factory/document_component.go
+++ b/service-app/internal/factory/document_component.go
@@ -3,8 +3,10 @@ package factory
 import (
 	"fmt"
 
+	"github.com/ministryofjustice/opg-scanning/internal/constants"
 	"github.com/ministryofjustice/opg-scanning/internal/parser"
 	"github.com/ministryofjustice/opg-scanning/internal/parser/corresp_parser"
+	"github.com/ministryofjustice/opg-scanning/internal/parser/generic_parser"
 	"github.com/ministryofjustice/opg-scanning/internal/parser/lp1f_parser"
 	"github.com/ministryofjustice/opg-scanning/internal/parser/lp1h_parser"
 	"github.com/ministryofjustice/opg-scanning/internal/parser/lpc_parser"
@@ -50,6 +52,14 @@ func GetComponent(docType string) (Component, error) {
 			},
 			Validator: lpc_parser.NewValidator(),
 			Sanitizer: lpc_parser.NewSanitizer(),
+		}, nil
+	case constants.DocumentTypeLPA002, constants.DocumentTypeLPAPA, constants.DocumentTypeLPAPW, constants.DocumentTypeLPA114, constants.DocumentTypeLPA117, constants.DocumentTypeLP2, constants.DocumentTypeEP2PG:
+		return Component{
+			Parser: func(data []byte) (interface{}, error) {
+				return generic_parser.Parse(data)
+			},
+			Validator: generic_parser.NewValidator(),
+			Sanitizer: generic_parser.NewSanitizer(),
 		}, nil
 	default:
 		return Component{}, fmt.Errorf("unsupported docType: %s", docType)

--- a/service-app/internal/ingestion/set_validator.go
+++ b/service-app/internal/ingestion/set_validator.go
@@ -27,23 +27,23 @@ func (v *Validator) ValidateSet(parsedSet *types.BaseSet) error {
 	}
 
 	// Validate combinations of instruments and applications
-	instrumentsDiscovered := v.getEmbeddedDocumentTypes(parsedSet, constants.Instruments)
-	applicationsDiscovered := v.getEmbeddedDocumentTypes(parsedSet, constants.Applications)
+	// instrumentsDiscovered := v.getEmbeddedDocumentTypes(parsedSet, constants.Instruments)
+	// applicationsDiscovered := v.getEmbeddedDocumentTypes(parsedSet, constants.Applications)
 
-	if parsedSet.Header.CaseNo != "" {
-		// Validate document combinations if CaseNo exists
-		if err := v.validateDocCombosWithCaseNo(instrumentsDiscovered, applicationsDiscovered); err != nil {
-			return err
-		}
-	} else {
-		// Validate document instruments if no CaseNo exists
-		if err := v.validateInstrumentCountWithoutCaseNo(instrumentsDiscovered); err != nil {
-			return err
-		}
-		if err := v.validateInstrumentApplications(instrumentsDiscovered, applicationsDiscovered); err != nil {
-			return err
-		}
-	}
+	// if parsedSet.Header.CaseNo != "" {
+	// 	// Validate document combinations if CaseNo exists
+	// 	if err := v.validateDocCombosWithCaseNo(instrumentsDiscovered, applicationsDiscovered); err != nil {
+	// 		return err
+	// 	}
+	// } else {
+	// 	// Validate document instruments if no CaseNo exists
+	// 	if err := v.validateInstrumentCountWithoutCaseNo(instrumentsDiscovered); err != nil {
+	// 		return err
+	// 	}
+	// 	if err := v.validateInstrumentApplications(instrumentsDiscovered, applicationsDiscovered); err != nil {
+	// 		return err
+	// 	}
+	// }
 
 	// Validate Body and Documents
 	if len(parsedSet.Body.Documents) == 0 {

--- a/service-app/internal/ingestion/set_validator.go
+++ b/service-app/internal/ingestion/set_validator.go
@@ -2,11 +2,9 @@ package ingestion
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/ministryofjustice/opg-scanning/internal/constants"
 	"github.com/ministryofjustice/opg-scanning/internal/types"
-	"github.com/ministryofjustice/opg-scanning/internal/util"
 )
 
 type Validator struct {
@@ -26,24 +24,9 @@ func (v *Validator) ValidateSet(parsedSet *types.BaseSet) error {
 		return errors.New("missing required Header element")
 	}
 
-	// Validate combinations of instruments and applications
-	// instrumentsDiscovered := v.getEmbeddedDocumentTypes(parsedSet, constants.Instruments)
-	// applicationsDiscovered := v.getEmbeddedDocumentTypes(parsedSet, constants.Applications)
-
-	// if parsedSet.Header.CaseNo != "" {
-	// 	// Validate document combinations if CaseNo exists
-	// 	if err := v.validateDocCombosWithCaseNo(instrumentsDiscovered, applicationsDiscovered); err != nil {
-	// 		return err
-	// 	}
-	// } else {
-	// 	// Validate document instruments if no CaseNo exists
-	// 	if err := v.validateInstrumentCountWithoutCaseNo(instrumentsDiscovered); err != nil {
-	// 		return err
-	// 	}
-	// 	if err := v.validateInstrumentApplications(instrumentsDiscovered, applicationsDiscovered); err != nil {
-	// 		return err
-	// 	}
-	// }
+	if parsedSet.Header.Schedule == "" {
+		return errors.New("missing required Schedule attribute on Header")
+	}
 
 	// Validate Body and Documents
 	if len(parsedSet.Body.Documents) == 0 {
@@ -52,49 +35,32 @@ func (v *Validator) ValidateSet(parsedSet *types.BaseSet) error {
 
 	for _, doc := range parsedSet.Body.Documents {
 		if doc.Type == "" {
-			return fmt.Errorf("document Type attribute is missing")
+			return errors.New("document Type attribute is missing")
 		}
 		if doc.NoPages <= 0 {
-			return fmt.Errorf("document NoPages attribute is missing or invalid")
+			return errors.New("document NoPages attribute is missing or invalid")
 		}
 	}
 
-	return nil
-}
+	// Validate combinations of instruments and applications
+	newCaseDocuments := v.getEmbeddedDocumentTypes(parsedSet, constants.NewCaseDocuments)
 
-func (v *Validator) validateDocCombosWithCaseNo(instruments []string, applications []string) error {
-	if len(instruments) == 0 && len(applications) == 0 {
-		return nil
-	}
-
-	if len(applications) == 1 && v.isExemptApplication(applications[0]) {
-		return nil
+	if len(newCaseDocuments) > 1 {
+		return errors.New("Set cannot contain multiple cases which would create a case")
 	}
 
-	fullList := append(instruments, applications...)
-	return fmt.Errorf("document(s) %s cannot be used if you have set a CaseNo in the Header", fullList)
-}
+	if len(newCaseDocuments) > 0 {
+		// Sets that create new cases must not have a case number
+		if parsedSet.Header.CaseNo != "" {
+			return errors.New("must not supply a case number when creating a new case")
+		}
+	} else {
+		// Sets that don't create new cases must have a case number
+		if parsedSet.Header.CaseNo == "" {
+			return errors.New("must supply a case number when not creating a new case")
+		}
+	}
 
-func (v *Validator) validateInstrumentCountWithoutCaseNo(instruments []string) error {
-	if len(instruments) == 0 {
-		return fmt.Errorf("no instrument found. Valid instruments are %s", constants.Instruments)
-	}
-	if len(instruments) > 1 {
-		return fmt.Errorf("too many instruments found. You may only supply one instrument. Set contained %s", instruments)
-	}
-	return nil
-}
-
-func (v *Validator) validateInstrumentApplications(instruments []string, applications []string) error {
-	if len(instruments) == 0 {
-		return nil
-	}
-	if v.isStandaloneInstrument(instruments[0]) && len(applications) > 0 {
-		return fmt.Errorf("instrument %s must not be accompanied by an application (%s)", instruments[0], applications)
-	}
-	if !v.isStandaloneInstrument(instruments[0]) && len(applications) != 1 {
-		return fmt.Errorf("instrument %s must be accompanied by one application. Found applications: %s", instruments[0], applications)
-	}
 	return nil
 }
 
@@ -109,12 +75,4 @@ func (v *Validator) getEmbeddedDocumentTypes(parsedSet *types.BaseSet, validType
 		}
 	}
 	return typesDiscovered
-}
-
-func (v *Validator) isExemptApplication(application string) bool {
-	return util.Contains(constants.ExemptApplications, application)
-}
-
-func (v *Validator) isStandaloneInstrument(instrument string) bool {
-	return util.Contains(constants.StandaloneInstruments, instrument)
 }

--- a/service-app/internal/ingestion/set_validator_test.go
+++ b/service-app/internal/ingestion/set_validator_test.go
@@ -1,0 +1,183 @@
+package ingestion
+
+import (
+	"testing"
+
+	"github.com/ministryofjustice/opg-scanning/internal/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetValidatorValidationRules(t *testing.T) {
+	tests := []struct {
+		Name         string
+		Set          types.BaseSet
+		ErrorMessage string
+	}{
+		{
+			Name: "missing <Header>",
+			Set: types.BaseSet{
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{Type: "LP1F", NoPages: 14},
+					},
+				},
+			},
+			ErrorMessage: "missing required Header element",
+		},
+		{
+			Name: "missing schedule attribute",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "",
+				},
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{Type: "LP1F", NoPages: 14},
+					},
+				},
+			},
+			ErrorMessage: "missing required Schedule attribute on Header",
+		},
+		{
+			Name: "missing documents",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "schedule-id",
+				},
+			},
+			ErrorMessage: "no Document elements found in Body",
+		},
+		{
+			Name: "document missing type",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "schedule-id",
+				},
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{NoPages: 14},
+					},
+				},
+			},
+			ErrorMessage: "document Type attribute is missing",
+		},
+		{
+			Name: "document missing NoPages",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "schedule-id",
+				},
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{Type: "LP1H"},
+					},
+				},
+			},
+			ErrorMessage: "document NoPages attribute is missing or invalid",
+		},
+		{
+			Name: "creating case with CaseNo set",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "schedule-id",
+					CaseNo:   "7000-0238-2394",
+				},
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{Type: "LP1H", NoPages: 14},
+					},
+				},
+			},
+			ErrorMessage: "must not supply a case number when creating a new case",
+		},
+		{
+			Name: "adding correspondence without CaseNo set",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "schedule-id",
+				},
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{Type: "Correspondence", NoPages: 5},
+					},
+				},
+			},
+			ErrorMessage: "must supply a case number when not creating a new case",
+		},
+		{
+			Name: "multiple case creators in one set",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "schedule-id",
+				},
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{Type: "LP1H", NoPages: 14},
+						{Type: "LP1F", NoPages: 16},
+					},
+				},
+			},
+			ErrorMessage: "Set cannot contain multiple cases which would create a case",
+		},
+		{
+			Name: "accepts new case document without CaseNo",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "schedule-id",
+				},
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{Type: "LP1H", NoPages: 14},
+					},
+				},
+			},
+			ErrorMessage: "",
+		},
+		{
+			Name: "accepts correspondence with CaseNo",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "schedule-id",
+					CaseNo:   "7000-0238-2394",
+				},
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{Type: "Correspondence", NoPages: 5},
+					},
+				},
+			},
+			ErrorMessage: "",
+		},
+		{
+			Name: "accepts mixed sets",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "schedule-id",
+				},
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{Type: "LP1H", NoPages: 14},
+						{Type: "Correspondence", NoPages: 5},
+					},
+				},
+			},
+			ErrorMessage: "",
+		},
+	}
+
+	v := NewValidator()
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			err := v.ValidateSet(&tc.Set)
+
+			if tc.ErrorMessage != "" {
+				assert.Equal(t, tc.ErrorMessage, err.Error())
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}

--- a/service-app/internal/parser/generic_parser/generic_parser.go
+++ b/service-app/internal/parser/generic_parser/generic_parser.go
@@ -1,0 +1,25 @@
+package generic_parser
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	"github.com/ministryofjustice/opg-scanning/internal/parser"
+)
+
+func Parse(data []byte) (interface{}, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("data is empty")
+	}
+
+	doc := &struct{}{}
+	if err := xml.Unmarshal(data, doc); err != nil {
+		return nil, err
+	}
+	// Validate required fields based on struct tags
+	if err := parser.ValidateStruct(doc); err != nil {
+		return nil, err
+	}
+
+	return doc, nil
+}

--- a/service-app/internal/parser/generic_parser/generic_sanitizer.go
+++ b/service-app/internal/parser/generic_parser/generic_sanitizer.go
@@ -1,0 +1,36 @@
+package generic_parser
+
+import (
+	"fmt"
+
+	"github.com/ministryofjustice/opg-scanning/internal/parser"
+)
+
+type Sanitizer struct {
+	doc           interface{}
+	baseSanitizer *parser.BaseSanitizer
+}
+
+func NewSanitizer() *Sanitizer {
+	return &Sanitizer{
+		doc: struct{}{},
+	}
+}
+
+func (v *Sanitizer) Setup(doc interface{}) error {
+	if doc == nil {
+		return fmt.Errorf("document is nil")
+	}
+
+	v.baseSanitizer = parser.NewBaseSanitizer(v.doc)
+
+	return nil
+}
+
+func (s *Sanitizer) Sanitize() (interface{}, error) {
+	if err := s.baseSanitizer.SanitizeStruct(s.doc); err != nil {
+		return nil, err
+	}
+
+	return s.doc, nil
+}

--- a/service-app/internal/parser/generic_parser/generic_validator.go
+++ b/service-app/internal/parser/generic_parser/generic_validator.go
@@ -1,20 +1,19 @@
-package corresp_parser
+package generic_parser
 
 import (
 	"fmt"
 
 	"github.com/ministryofjustice/opg-scanning/internal/parser"
-	"github.com/ministryofjustice/opg-scanning/internal/types/corresp_types"
 )
 
 type Validator struct {
-	doc           *corresp_types.Correspondence
+	doc           interface{}
 	baseValidator *parser.BaseValidator
 }
 
 func NewValidator() *Validator {
 	return &Validator{
-		doc: &corresp_types.Correspondence{},
+		doc: struct{}{},
 	}
 }
 
@@ -23,7 +22,6 @@ func (v *Validator) Setup(doc interface{}) error {
 		return fmt.Errorf("document is nil")
 	}
 
-	v.doc = doc.(*corresp_types.Correspondence)
 	v.baseValidator = parser.NewBaseValidator(v.doc)
 
 	return nil
@@ -32,7 +30,7 @@ func (v *Validator) Setup(doc interface{}) error {
 func (v *Validator) Validate() error {
 	// Return errors if any
 	if messages := v.baseValidator.GetValidatorErrorMessages(); len(messages) > 0 {
-		return fmt.Errorf("failed to validate correspondence document: %v", messages)
+		return fmt.Errorf("failed to validate generic document: %v", messages)
 	}
 	return nil
 }


### PR DESCRIPTION
## To allow documents to arrive separately

Remove the validation requiring instrument/application combinations in `set_validator.go`.

However, this should be replaced by validation to ensure that e.g. LP2 documents have no `CaseNo` because they create new cases, but LPA117 documents must have a `CaseNo`

## To support additional documents

For the extra documents we want to add quick support for, use a new `generic_parser` that doesn't need to have the XML structure mapped to Go. It is still validated against the XSD during parsing.

These documents are automatically sent on to Sirius, but we should replace this with an allowlist ([SSM-46](https://opgtransform.atlassian.net/browse/SSM-46)).


[SSM-46]: https://opgtransform.atlassian.net/browse/SSM-46?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ