### PR TITLE
Allow documents to be sent separately

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -18,5 +18,3 @@ _Any tips and tricks, blog posts or tools which helped you._
 * [ ] I have added relevant logging with appropriate levels to my code
 * [ ] I have updated documentation where relevant
 * [ ] I have added tests to prove my work
-* [ ] I have run an accessibility tool against the changes and applied fixes
-* [ ] The team have tested these changes

--- a/service-app/internal/constants/document_types.go
+++ b/service-app/internal/constants/document_types.go
@@ -41,33 +41,13 @@ var (
 		DocumentTypeEPA,
 	}
 
-	Instruments = []string{
-		DocumentTypeEPA,
-		DocumentTypeLPAPW,
-		DocumentTypeLPAPA,
-		DocumentTypeLPA114,
-		DocumentTypeLPA117,
-		DocumentTypeLP1F,
-		DocumentTypeLP1H,
-	}
-
-	Applications = []string{
+	NewCaseDocuments = []string{
 		DocumentTypeEP2PG,
 		DocumentTypeLPA002,
 		DocumentTypeLP0002R,
 		DocumentTypeLP2,
-	}
-
-	CourtOrderDocuments = []string{
-		DocumentTypeCOPORD,
-	}
-
-	StandaloneInstruments = []string{
 		DocumentTypeLP1F,
 		DocumentTypeLP1H,
-	}
-
-	ExemptApplications = []string{
-		DocumentTypeLP0002R,
+		DocumentTypeCOPORD,
 	}
 )

--- a/service-app/internal/ingestion/set_validator_test.go
+++ b/service-app/internal/ingestion/set_validator_test.go
@@ -1,0 +1,183 @@
+package ingestion
+
+import (
+	"testing"
+
+	"github.com/ministryofjustice/opg-scanning/internal/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetValidatorValidationRules(t *testing.T) {
+	tests := []struct {
+		Name         string
+		Set          types.BaseSet
+		ErrorMessage string
+	}{
+		{
+			Name: "missing <Header>",
+			Set: types.BaseSet{
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{Type: "LP1F", NoPages: 14},
+					},
+				},
+			},
+			ErrorMessage: "missing required Header element",
+		},
+		{
+			Name: "missing schedule attribute",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "",
+				},
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{Type: "LP1F", NoPages: 14},
+					},
+				},
+			},
+			ErrorMessage: "missing required Schedule attribute on Header",
+		},
+		{
+			Name: "missing documents",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "schedule-id",
+				},
+			},
+			ErrorMessage: "no Document elements found in Body",
+		},
+		{
+			Name: "document missing type",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "schedule-id",
+				},
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{NoPages: 14},
+					},
+				},
+			},
+			ErrorMessage: "document Type attribute is missing",
+		},
+		{
+			Name: "document missing NoPages",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "schedule-id",
+				},
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{Type: "LP1H"},
+					},
+				},
+			},
+			ErrorMessage: "document NoPages attribute is missing or invalid",
+		},
+		{
+			Name: "creating case with CaseNo set",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "schedule-id",
+					CaseNo:   "7000-0238-2394",
+				},
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{Type: "LP1H", NoPages: 14},
+					},
+				},
+			},
+			ErrorMessage: "must not supply a case number when creating a new case",
+		},
+		{
+			Name: "adding correspondence without CaseNo set",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "schedule-id",
+				},
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{Type: "Correspondence", NoPages: 5},
+					},
+				},
+			},
+			ErrorMessage: "must supply a case number when not creating a new case",
+		},
+		{
+			Name: "multiple case creators in one set",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "schedule-id",
+				},
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{Type: "LP1H", NoPages: 14},
+						{Type: "LP1F", NoPages: 16},
+					},
+				},
+			},
+			ErrorMessage: "Set cannot contain multiple cases which would create a case",
+		},
+		{
+			Name: "accepts new case document without CaseNo",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "schedule-id",
+				},
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{Type: "LP1H", NoPages: 14},
+					},
+				},
+			},
+			ErrorMessage: "",
+		},
+		{
+			Name: "accepts correspondence with CaseNo",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "schedule-id",
+					CaseNo:   "7000-0238-2394",
+				},
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{Type: "Correspondence", NoPages: 5},
+					},
+				},
+			},
+			ErrorMessage: "",
+		},
+		{
+			Name: "accepts mixed sets",
+			Set: types.BaseSet{
+				Header: &types.BaseHeader{
+					Schedule: "schedule-id",
+				},
+				Body: types.BaseBody{
+					Documents: []types.BaseDocument{
+						{Type: "LP1H", NoPages: 14},
+						{Type: "Correspondence", NoPages: 5},
+					},
+				},
+			},
+			ErrorMessage: "",
+		},
+	}
+
+	v := NewValidator()
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			err := v.ValidateSet(&tc.Set)
+
+			if tc.ErrorMessage != "" {
+				assert.Equal(t, tc.ErrorMessage, err.Error())
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Purpose

Rather than requiring instruments and applications to be sent in the same set, allow any document to be sent individually.

But add some new validation rules to protect against confusing circumstances: documents either create cases or they don't, and the presence of `CaseNo` is dependent on there being no case-creators in the set. Also you can't have two case-creators in the same set.

I also got rid of a few constants that are no longer used.

Fixes SSM-63 #major

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work