### PR TITLE
Add golangci-lint and gosec

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
     name: "Docker build, trivy scan, ECR push"
     runs-on: ubuntu-latest
     # require all steps before this matrix to have passed
-    needs: [branch_name, workspace_name, semver_tag]
+    needs: [branch_name, workspace_name, semver_tag, gosec, go-lint]
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
   security-events: write
   actions: read
-  checks: read
+  checks: write
   deployments: none
   issues: none
   packages: none
@@ -37,6 +37,34 @@ jobs:
     uses: ministryofjustice/opg-github-workflows/.github/workflows/analysis-application-codeql-sast-to-github-security.yml@v3.6.0
     with:
       application_languages: '["go"]'
+
+  golint:
+    name: Go Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          working-directory: service-app
+
+  gosec:
+    name: Go Sec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Go Sec
+        continue-on-error: true
+        run: make gosec
+      - name: Upload GoSec results to GitHub Security tab
+        if: ${{ always() }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'test-results/gosec.sarif'
+          category: gosec
 
   # generate tag
   semver_tag:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
   security-events: write
   actions: read
-  checks: write
+  checks: read
   deployments: none
   issues: none
   packages: none
@@ -38,27 +38,27 @@ jobs:
     with:
       application_languages: '["go"]'
 
-  golint:
+  go-lint:
     name: Go Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - run: make go-lint
+        continue-on-error: true
+      - name: Upload golangci-lint results to GitHub Security tab
+        if: ${{ always() }}
+        uses: github/codeql-action/upload-sarif@v3
         with:
-          go-version: stable
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          working-directory: service-app
+          sarif_file: 'test-results/go-lint.sarif'
+          category: golangci-lint
 
   gosec:
     name: Go Sec
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Go Sec
+      - run: make gosec
         continue-on-error: true
-        run: make gosec
       - name: Upload GoSec results to GitHub Security tab
         if: ${{ always() }}
         uses: github/codeql-action/upload-sarif@v3

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ venv/
 env/
 # build
 .cache
+test-results

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ secrets.auto.tfvars
 .env
 venv/
 env/
+# build
+.cache

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,6 @@ start-sirius:
 clean:
 	@echo "Stopping and cleaning up Docker Compose resources..."
 	@docker-compose down --remove-orphans --volumes || { echo "Failed to clean up resources"; exit 1; }
+
+gosec:
+	docker compose run --rm gosec

--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,8 @@ clean:
 setup-directories:
 	mkdir -p -m 0777 test-results
 
+go-lint: setup-directories
+	docker compose run --rm go-lint
+
 gosec: setup-directories
 	docker compose run --rm gosec

--- a/Makefile
+++ b/Makefile
@@ -26,5 +26,8 @@ clean:
 	@echo "Stopping and cleaning up Docker Compose resources..."
 	@docker-compose down --remove-orphans --volumes || { echo "Failed to clean up resources"; exit 1; }
 
-gosec:
+setup-directories:
+	mkdir -p -m 0777 test-results
+
+gosec: setup-directories
 	docker compose run --rm gosec

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,3 +80,10 @@ services:
       timeout: 10s
       retries: 5
     restart: unless-stopped
+
+  gosec:
+    image: securego/gosec:latest
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: -exclude-dir=.gocache -fmt=sarif -out=/app/test-results/gosec.sarif -stdout -verbose=text /app/...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,5 +85,5 @@ services:
     image: securego/gosec:latest
     working_dir: /app
     volumes:
-      - .:/app
+      - ./service-app:/app
     command: -exclude-dir=.gocache -fmt=sarif -out=/app/test-results/gosec.sarif -stdout -verbose=text /app/...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,14 @@ services:
       retries: 5
     restart: unless-stopped
 
+  go-lint:
+    build: docker/go-lint
+    working_dir: /go/src/app/service-app
+    volumes:
+      - ./:/go/src/app
+      - ./.cache/golangci-lint/v1.64.5:/root/.cache
+    command: golangci-lint run -v --timeout 5m --out-format=sarif:/go/src/app/test-results/go-lint.sarif,colored-line-number --modules-download-mode=readonly
+
   gosec:
     image: securego/gosec:latest
     working_dir: /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,5 +85,5 @@ services:
     image: securego/gosec:latest
     working_dir: /app
     volumes:
-      - ./service-app:/app
+      - .:/app
     command: -exclude-dir=.gocache -fmt=sarif -out=/app/test-results/gosec.sarif -stdout -verbose=text /app/...

--- a/docker/go-lint/Dockerfile
+++ b/docker/go-lint/Dockerfile
@@ -1,0 +1,3 @@
+FROM golangci/golangci-lint:v1.64.5-alpine
+
+RUN apk add libxml2-dev

--- a/service-app/internal/api/handler.go
+++ b/service-app/internal/api/handler.go
@@ -78,7 +78,10 @@ func NewIndexController(awsClient aws.AwsClientInterface, appConfig *config.Conf
 func (c *IndexController) HandleRequests() {
 	http.Handle("/health-check", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK"))
+
+		if _, err := w.Write([]byte("OK")); err != nil {
+			c.logger.Error(err.Error(), nil)
+		}
 	}))
 
 	// Create the route to handle user authentication and issue JWT token
@@ -90,7 +93,9 @@ func (c *IndexController) HandleRequests() {
 	))
 
 	c.logger.Info("Starting server on :"+c.config.HTTP.Port, nil)
-	http.ListenAndServe(":"+c.config.HTTP.Port, nil)
+	if err := http.ListenAndServe(":"+c.config.HTTP.Port, nil); err != nil {
+		c.logger.Error(err.Error(), nil)
+	}
 }
 
 func (c *IndexController) AuthHandler(w http.ResponseWriter, r *http.Request) {

--- a/service-app/internal/api/handler.go
+++ b/service-app/internal/api/handler.go
@@ -93,7 +93,13 @@ func (c *IndexController) HandleRequests() {
 	))
 
 	c.logger.Info("Starting server on :"+c.config.HTTP.Port, nil)
-	if err := http.ListenAndServe(":"+c.config.HTTP.Port, nil); err != nil {
+
+	server := &http.Server{
+		Addr:              ":" + c.config.HTTP.Port,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	if err := server.ListenAndServe(); err != nil {
 		c.logger.Error(err.Error(), nil)
 	}
 }

--- a/service-app/internal/api/handler_test.go
+++ b/service-app/internal/api/handler_test.go
@@ -76,7 +76,8 @@ func TestIngestHandler_SetValid(t *testing.T) {
 	responseBody, _ := io.ReadAll(resp.Body)
 	var responseObj response
 
-	json.Unmarshal(responseBody, &responseObj)
+	err := json.Unmarshal(responseBody, &responseObj)
+	assert.Nil(t, err)
 	assert.True(t, responseObj.Data.Success)
 	assert.Equal(t, "700012341234", responseObj.Data.Uid)
 }
@@ -142,7 +143,8 @@ func TestIngestHandler_InvalidEmbeddedXMLProvidesDetails(t *testing.T) {
 	responseBody, _ := io.ReadAll(resp.Body)
 	var responseObj response
 
-	json.Unmarshal(responseBody, &responseObj)
+	err := json.Unmarshal(responseBody, &responseObj)
+	assert.Nil(t, err)
 	assert.False(t, responseObj.Data.Success)
 	assert.Contains(t, responseObj.Data.ValidationErrors, "Element 'LP2': Missing child element(s). Expected is ( Page1 ).")
 }

--- a/service-app/internal/factory/document_processor.go
+++ b/service-app/internal/factory/document_processor.go
@@ -67,7 +67,11 @@ func (p *DocumentProcessor) Process(ctx context.Context) (interface{}, error) {
 
 	// Validate the document
 	traceID, _ := ctx.Value(constants.TraceIDKey).(string)
-	p.validator.Setup(p.doc)
+
+	if err := p.validator.Setup(p.doc); err != nil {
+		return nil, fmt.Errorf("validation setup failed: %w", err)
+	}
+
 	if err := p.validator.Validate(); err != nil {
 		p.logger.Error("Validation failed: "+err.Error(), map[string]interface{}{
 			"trace_id": traceID,
@@ -75,7 +79,10 @@ func (p *DocumentProcessor) Process(ctx context.Context) (interface{}, error) {
 	}
 
 	// Sanitize the document
-	p.sanitizer.Setup(p.doc)
+	if err := p.sanitizer.Setup(p.doc); err != nil {
+		return nil, fmt.Errorf("sanitization setup failed: %w", err)
+	}
+
 	sanitizedDoc, err := p.sanitizer.Sanitize()
 	if err != nil {
 		return nil, fmt.Errorf("sanitization failed: %w", err)

--- a/service-app/internal/parser/lp1f_parser/lp1f_validator_test.go
+++ b/service-app/internal/parser/lp1f_parser/lp1f_validator_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ministryofjustice/opg-scanning/internal/parser"
 	"github.com/ministryofjustice/opg-scanning/internal/util"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -70,6 +71,9 @@ func getValidator(t *testing.T, fileName string) parser.CommonValidator {
 	doc, err := Parse(xml)
 	require.NoError(t, err)
 	validator := NewValidator()
-	validator.Setup(doc)
+
+	err = validator.Setup(doc)
+	assert.Nil(t, err)
+
 	return validator
 }

--- a/service-app/internal/parser/lp1h_parser/lp1h_validator_test.go
+++ b/service-app/internal/parser/lp1h_parser/lp1h_validator_test.go
@@ -22,7 +22,6 @@ func getValidator(t *testing.T, fileName string) parser.CommonValidator {
 	doc, err := Parse(xml)
 	require.NoError(t, err)
 	validator := NewValidator()
-	validator.Setup(doc)
 
 	err = validator.Setup(doc)
 	assert.Nil(t, err)

--- a/service-app/internal/parser/lp1h_parser/lp1h_validator_test.go
+++ b/service-app/internal/parser/lp1h_parser/lp1h_validator_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ministryofjustice/opg-scanning/internal/parser"
 	"github.com/ministryofjustice/opg-scanning/internal/util"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,5 +23,9 @@ func getValidator(t *testing.T, fileName string) parser.CommonValidator {
 	require.NoError(t, err)
 	validator := NewValidator()
 	validator.Setup(doc)
+
+	err = validator.Setup(doc)
+	assert.Nil(t, err)
+
 	return validator
 }

--- a/service-app/internal/parser/lpc_parser/lpc_validator_test.go
+++ b/service-app/internal/parser/lpc_parser/lpc_validator_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ministryofjustice/opg-scanning/internal/parser"
 	"github.com/ministryofjustice/opg-scanning/internal/util"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,6 +57,9 @@ func getLPCValidator(t *testing.T, fileName string) parser.CommonValidator {
 	require.NoError(t, err, "Failed to parse %s", fileName)
 
 	validator := NewValidator()
-	validator.Setup(doc)
+
+	err = validator.Setup(doc)
+	assert.Nil(t, err)
+
 	return validator
 }


### PR DESCRIPTION
To actively monitor for and alert us to risky code

Also fix some issues raised:
- Always handle `error` return values
- Set `ReadHeaderTimeout` on the HTTP server

#patch