### PR TITLE
Add Sirius mock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,11 @@ start:
 	@echo "Running the application using Docker Compose..."
 	@docker-compose up -d || { echo "Failed to start Docker Compose"; exit 1; }
 
+start-sirius:
+	@${MAKE} build
+	@echo "Running the application using Docker Compose, integrated with local Sirius..."
+	@docker-compose -f docker-compose.yml -f docker-compose.sirius.yml up -d || { echo "Failed to start Docker Compose"; exit 1; }
+
 clean:
 	@echo "Stopping and cleaning up Docker Compose resources..."
 	@docker-compose down --remove-orphans --volumes || { echo "Failed to clean up resources"; exit 1; }

--- a/docker-compose.sirius.yml
+++ b/docker-compose.sirius.yml
@@ -1,0 +1,21 @@
+services:
+  localstack: !reset null
+  sirius-mock: !reset null
+
+  service-app:
+    environment:
+      - SIRIUS_BASE_URL=http://api
+    networks:
+      - opg-sirius_default
+    depends_on: !reset null
+
+  service-app-test:
+    environment:
+      - SIRIUS_BASE_URL=http://api
+    networks:
+      - opg-sirius_default
+    depends_on: !reset null
+
+networks:
+  opg-sirius_default:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "8081:8081"
     environment:
-      - SIRIUS_BASE_URL=http://api
+      - SIRIUS_BASE_URL=http://sirius-mock:8080
       - AWS_ENDPOINT=http://localstack:4566
       - AWS_ACCESS_KEY_ID=test
       - AWS_SECRET_ACCESS_KEY=test
@@ -19,16 +19,13 @@ services:
     depends_on:
       localstack:
         condition: service_healthy
-    networks:
-      - opg-scanning_network
-      - opg-sirius_default
 
   service-app-test:
     build:
       context: ./service-app
       target: build-env
     environment:
-      - SIRIUS_BASE_URL=http://api
+      - SIRIUS_BASE_URL=http://sirius-mock:8080
       - AWS_ENDPOINT=http://localstack:4566
       - AWS_ACCESS_KEY_ID=test
       - AWS_SECRET_ACCESS_KEY=test
@@ -50,9 +47,6 @@ services:
     depends_on:
       localstack:
         condition: service_healthy
-    networks:
-      - opg-scanning_network
-      - opg-sirius_default
 
   localstack:
     image: localstack/localstack:3.8
@@ -65,9 +59,7 @@ services:
       AWS_DEFAULT_REGION: eu-west-1
       SERVICES: "s3,secretsmanager,sqs,ssm"
       DEBUG: 1
-      DATA_DIR: /var/lib/localstack/data
-    networks:
-      - opg-scanning_network
+      DATA_DIR: /var/lib/locals
     ports:
       - "4566:4566"
       - "4571:4571"
@@ -76,10 +68,15 @@ services:
       interval: 5s
       timeout: 10s
       retries: 5
-    restart: unless-stopped  
+    restart: unless-stopped
 
-networks:
-  opg-scanning_network:
-    driver: bridge
-  opg-sirius_default:
-    external: true
+  sirius-mock:
+    image: outofcoffee/imposter:4.5.7
+    volumes:
+      - ./docker/sirius:/opt/imposter/config
+    healthcheck:
+      test: ["CMD", "imposter", "list", "-x"]
+      interval: 5s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped

--- a/docker/sirius/imposter-config.yaml
+++ b/docker/sirius/imposter-config.yaml
@@ -1,0 +1,2 @@
+plugin: openapi
+specFile: openapi.yaml

--- a/docker/sirius/openapi.yaml
+++ b/docker/sirius/openapi.yaml
@@ -1,0 +1,156 @@
+openapi: "3.0.0"
+paths:
+  /api/public/v1/scanned-cases:
+    post:
+      description: Create a case stub from a scanned document
+      operationId: createScannedCase
+      requestBody:
+        description: Details of the scan
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - batchId
+                - caseType
+                - receiptDate
+              properties:
+                batchId:
+                  type: string
+                  examples:
+                    - "01-0001269-20160909174222"
+                caseType:
+                  type: string
+                  enum:
+                    - epa
+                    - lpa
+                    - order
+                courtReference:
+                  type: string
+                  description: Required when creating new orders
+                receiptDate:
+                  type: string
+                  formate: date-time
+      responses:
+        "201":
+          description: Scanned case created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - uid
+                properties:
+                  uid:
+                    type: string
+                    example: 7000-1234-1234
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Case not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/public/v1/scanned-documents/scanned-documents:
+    post:
+      description: Attach a scanned document to a case
+      operationId: createScannedDocument
+      requestBody:
+        description: The scanned document
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - caseReference
+                - content
+                - documentType
+                - scannedDate
+              properties:
+                caseReference:
+                  type: string
+                  examples:
+                    - "7000-1209-2049"
+                    - "M-123F-29JF-EI93"
+                content:
+                  type: string
+                  description: Base-64 encoded content of the file
+                documentType:
+                  type: string
+                  pattern: "^[a-zA-Z0-9_\\-]+$"
+                  description: Type attribute on Document element of Set
+                  examples:
+                    - LP1F
+                    - Correspondence
+                    - FINDOCS
+                documentSubType:
+                  type: string
+                  description: SubType element of decoded XML for Correspondence
+                  examples:
+                    - safeguarding concern
+                scannedDate:
+                  type: string
+                  format: date-time
+      responses:
+        "201":
+          description: Scanned document created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - uuid
+                properties:
+                  uuid:
+                    type: string
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Case not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      required:
+        - type
+        - status
+        - detail
+        - validation_errors
+      properties:
+        type:
+          type: string
+          enum: ["http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html"]
+        title:
+          type: string
+          description: A string representation of the status code
+          examples:
+            - Bad Request
+        status:
+          type: string
+          description: The HTTP status code
+          examples:
+            - "400"
+        detail:
+          type: string
+          description: A human-readable description of the error. Can be shown to a user
+          examples:
+            - Payload failed validation
+        validation_errors:
+          type: object
+          description: Validation errors for specific fields. A map with invalid field names as keys and values which are themselves maps from validation error ID to human-readable message.
+          examples:
+            - caseUid:
+                invalidFormat: The UID was not in a recognised format


### PR DESCRIPTION
# Purpose

Adds an imposter container that mocks Sirius's behaviour, which removes the requirement for an external network.

This will also allow us to stand up the app in the CI pipeline for testing.

Fixes SSM-19 #minor

## Approach

But integrating with Sirius is helpful, because it lets us do end-to-end tests and check mapping of the XML document, so I've added an additional `docker-compose.sirius.yml` file which uses (and requires) Sirius to be running locally.

Therefore:
- `make start` allows you to do a minimal local stand-up of the app
- `make start-sirius` requires Sirius to be running locally and lets you ingest documents fully

## Learning

`!reset null` is really useful!

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
  * N/A
