### PR TITLE
Run `gomodTidy` after Renovate PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "prConcurrentLimit": 0,
   "branchConcurrentLimit": 0,
   "configMigration": true,
+  "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
     {
       "groupName": "Minor & Patch Updates",


### PR DESCRIPTION
Will run `go mod tidy` to remove unused dependencies from `go.sum`, keeping our dependency files cleaner and reducing false positives in vulnerability scanning tools.

#patch
