### PR TITLE
Add an allowlist for document types to send to Sirius

### DIFF
--- a/docker/sirius/openapi.yaml
+++ b/docker/sirius/openapi.yaml
@@ -56,7 +56,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /api/public/v1/scanned-documents/scanned-documents:
+  /api/public/v1/scanned-documents:
     post:
       description: Attach a scanned document to a case
       operationId: createScannedDocument

--- a/service-app/internal/api/handler.go
+++ b/service-app/internal/api/handler.go
@@ -239,8 +239,8 @@ func (c *IndexController) IngestHandler(w http.ResponseWriter, r *http.Request) 
 				return
 			}
 
-			// Check if the document is a correspondence type; if so do not send to the job queue
-			if util.Contains([]string{"Correspondence", "SupCorrespondence"}, originalDoc.Type) {
+			// Check if the document should be sent Sirius; if not, skip
+			if !util.Contains(constants.SiriusExtractionDocuments, originalDoc.Type) {
 				c.logger.Info("Skipping external job processing, checks completed for document", map[string]interface{}{
 					"trace_id":      reqID,
 					"set_uid":       scannedCaseResponse.UID,

--- a/service-app/internal/constants/document_types.go
+++ b/service-app/internal/constants/document_types.go
@@ -62,4 +62,13 @@ var (
 		DocumentTypeLP1H,
 		DocumentTypeCOPORD,
 	}
+
+	// these documents should be sent to Sirius to be extracted
+	SiriusExtractionDocuments = []string{
+		DocumentTypeEP2PG,
+		DocumentTypeLP1F,
+		DocumentTypeLP1H,
+		DocumentTypeLP2,
+		DocumentTypeLPC,
+	}
 )


### PR DESCRIPTION
# Purpose

Only some documents should be sent to Sirius for processing. To avoid computation and confusion, implement an allowlist.

Also fixed a mistake in the Sirius mock OpenAPI file.

Fixes SSM-61 #major

## Approach

I reused the existing logic which excludes correspondence, but changed it to look at an allowlist.

## Learning

Testing whether something was sent to the queue is difficult because it's constructed from globals in the handler. We may want to refactor that to make it mockable and easier to test.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [ ] I have added tests to prove my work
