### PR TITLE
feat/SSM-80: added HasPrefix check to content-type header validation

### DIFF
--- a/service-app/internal/api/handler.go
+++ b/service-app/internal/api/handler.go
@@ -168,7 +168,7 @@ func (c *IndexController) IngestHandler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	contentType := r.Header.Get("Content-Type")
-	if contentType != "application/xml" && contentType != "text/xml" {
+	if !(strings.HasPrefix(contentType, "application/xml") || strings.HasPrefix(contentType, "text/xml")) {
 		c.respondWithError(reqCtx, w, http.StatusBadRequest, "Invalid content type", fmt.Errorf("expected application/xml or text/xml, got %s", contentType))
 		return
 	}


### PR DESCRIPTION
# Purpose

More robust validation added using `hasPrefix` to check beginning of header value matches expectation.

Fixes SSM-80

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
