### PR TITLE
Stop reusing context

### DIFF
--- a/service-app/internal/api/handler.go
+++ b/service-app/internal/api/handler.go
@@ -215,7 +215,7 @@ func (c *IndexController) IngestHandler(w http.ResponseWriter, r *http.Request) 
 			// Extract the enriched logger from the original request context.
 			enrichedLogger := logger.LoggerFromContext(reqCtx)
 			// Create a new context starting with reqCtx and inject the enriched logger.
-			loggerCtx := logger.ContextWithLogger(reqCtx, enrichedLogger)
+			loggerCtx := logger.ContextWithLogger(context.Background(), enrichedLogger)
 			// Then apply your timeout on the new context.
 			ctx, cancel := context.WithTimeout(loggerCtx, time.Duration(c.config.HTTP.Timeout)*time.Second)
 			defer cancel()
@@ -317,7 +317,7 @@ func (c *IndexController) respondWithError(ctx context.Context, w http.ResponseW
 	c.logger.ErrorWithContext(ctx, message, map[string]interface{}{
 		"error": err,
 	})
-	
+
 	resp := response{
 		Data: responseData{
 			Success: false,


### PR DESCRIPTION
# Purpose

`loggerCtx` was created by extending the existing context, but this gets cancelled before the queued job is executed.

Fixes SSM-81 #patch

## Approach

Create a new context and attach the logger/timeout to it.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
