### PR TITLE
Logging improvements

### DIFF
--- a/service-app/internal/api/handler.go
+++ b/service-app/internal/api/handler.go
@@ -298,7 +298,9 @@ func (c *IndexController) IngestHandler(w http.ResponseWriter, r *http.Request) 
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		c.respondWithError(reqCtx, w, http.StatusInternalServerError, "Failed to encode response", err)
 	} else {
-		c.logger.InfoWithContext(reqCtx, "Ingestion request processed successfully, UID: %s", nil, scannedCaseResponse.UID)
+		c.logger.InfoWithContext(reqCtx, "Ingestion request processed successfully", map[string]interface{}{
+			"uid": scannedCaseResponse.UID,
+		})
 	}
 }
 
@@ -307,9 +309,15 @@ func (c *IndexController) CloseQueue() {
 }
 
 func (c *IndexController) respondWithError(ctx context.Context, w http.ResponseWriter, statusCode int, message string, err error) {
-	c.logger.ErrorWithContext(ctx, message, map[string]interface{}{
-		"error": err,
-	})
+	if statusCode >= 500 {
+		c.logger.ErrorWithContext(ctx, message, map[string]interface{}{
+			"error": err,
+		})
+	} else {
+		c.logger.InfoWithContext(ctx, message, map[string]interface{}{
+			"error": err,
+		})
+	}
 
 	resp := response{
 		Data: responseData{

--- a/service-app/internal/factory/document_processor.go
+++ b/service-app/internal/factory/document_processor.go
@@ -70,9 +70,9 @@ func (p *DocumentProcessor) Process(ctx context.Context) (interface{}, error) {
 	}
 
 	if err := p.validator.Validate(); err != nil {
-		p.logger.Error("Validation failed: %v", nil, err)
+		p.logger.Info("Validation failed: %v", nil, err)
 	}
-	
+
 	// Sanitize the document
 	if err := p.sanitizer.Setup(p.doc); err != nil {
 		return nil, fmt.Errorf("sanitization setup failed: %w", err)


### PR DESCRIPTION
# Purpose

- Pass `uid` as a log argument rather than trying to substitute it into the message (which isn't working)
- Log validation and 4xx errors at INFO level. ERROR level is reserved from problems with the service since it triggers on-call alarms

Fixes SSM-85 #patch

## Checklist

* [x] I have performed a self-review of my own code
