### PR TITLE
Add integration test script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,24 @@ jobs:
           sarif_file: 'test-results/gosec.sarif'
           category: gosec
 
+  # Unit test
+  unit-test:
+    name: Unit test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make test
+
+  # Integration test
+  integration-test:
+    name: Integration test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make integration-test
+      - run: make clean
+        if: ${{ always() }}
+
   # generate tag
   semver_tag:
     needs: [branch_name, codeql_analysis]
@@ -78,12 +96,11 @@ jobs:
   # Docker build, trivy scan, ECR push as a matrix
   # The matrix loops over each app to build in a complicated
   # structure
-  # ADD IN ECR PUSH
   build_scan_push:
     name: "Docker build, trivy scan, ECR push"
     runs-on: ubuntu-latest
     # require all steps before this matrix to have passed
-    needs: [branch_name, workspace_name, semver_tag, gosec, go-lint]
+    needs: [branch_name, workspace_name, semver_tag, gosec, go-lint, unit-test, integration-test]
     strategy:
       fail-fast: true
       matrix:
@@ -91,7 +108,6 @@ jobs:
         data:
           - docker_build_directory: "./service-app"
             image_app_name: "service-app"
-            test_command: "go test ./..."
     # we use these a few times, so its easier to generate them once and env
     # vars are visible in the output, so helps with debug
     env:
@@ -144,13 +160,6 @@ jobs:
         if: always()
         with:
           sarif_file: ${{ env.sarif_file }}
-      # for a lot of our services, there could be a test process here
-      - name: Run Tests
-        working-directory: ${{ matrix.data.docker_build_directory }}
-        env:
-          PROJECT_PATH: service-app
-        run: |
-          ${{ matrix.data.test_command }}
       ######
       ## Push to ECR
       ######

--- a/Makefile
+++ b/Makefile
@@ -4,27 +4,32 @@ all: test start clean
 
 test:
 	@echo "Running tests in the service-app-test container..."
-	@docker-compose build service-app-test || { echo "Failed to build the service-app-test image"; exit 1; }
-	@docker-compose run --rm service-app-test || { echo "Tests failed"; exit 1; }
-	@docker-compose down --remove-orphans --volumes service-app-test
+	@docker compose build service-app-test || { echo "Failed to build the service-app-test image"; exit 1; }
+	@docker compose run --rm service-app-test || { echo "Tests failed"; exit 1; }
+	@docker compose down --remove-orphans --volumes service-app-test
+
+integration-test:
+	@${MAKE} start
+	bash ./tester/test.sh
+	@${MAKE} clean
 
 build:
 	@echo "Building the application..."
-	@docker-compose build || { echo "Failed to build the application image"; exit 1; }
+	@docker compose build || { echo "Failed to build the application image"; exit 1; }
 
 start:
 	@${MAKE} build
 	@echo "Running the application using Docker Compose..."
-	@docker-compose up -d || { echo "Failed to start Docker Compose"; exit 1; }
+	@docker compose up -d || { echo "Failed to start Docker Compose"; exit 1; }
 
 start-sirius:
 	@${MAKE} build
 	@echo "Running the application using Docker Compose, integrated with local Sirius..."
-	@docker-compose -f docker-compose.yml -f docker-compose.sirius.yml up -d || { echo "Failed to start Docker Compose"; exit 1; }
+	@docker compose -f docker-compose.yml -f docker-compose.sirius.yml up -d || { echo "Failed to start Docker Compose"; exit 1; }
 
 clean:
 	@echo "Stopping and cleaning up Docker Compose resources..."
-	@docker-compose down --remove-orphans --volumes || { echo "Failed to clean up resources"; exit 1; }
+	@docker compose down --remove-orphans --volumes || { echo "Failed to clean up resources"; exit 1; }
 
 setup-directories:
 	mkdir -p -m 0777 test-results

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - "4566:4566"
       - "4571:4571"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+      test: ["CMD", "bash", "/scripts/wait/healthcheck.sh"]
       interval: 5s
       timeout: 10s
       retries: 5

--- a/docker/sirius/imposter-config.yaml
+++ b/docker/sirius/imposter-config.yaml
@@ -1,2 +1,8 @@
 plugin: openapi
 specFile: openapi.yaml
+
+resources:
+  - method: POST
+    path: /api/public/v1/scanned-cases
+    response:
+      scriptFile: scanned-cases-endpoint.js

--- a/docker/sirius/scanned-cases-endpoint.js
+++ b/docker/sirius/scanned-cases-endpoint.js
@@ -1,0 +1,11 @@
+const { respond, stores } = require("@imposter-js/types");
+
+const lpaIdStore = stores.open("lpaIdStore");
+
+const lpaIdCounter = lpaIdStore.load("counter") ?? 100;
+
+respond()
+  .withStatusCode(201)
+  .withContent(`{"uid":"${700000000000 + lpaIdCounter}"}`);
+
+lpaIdStore.save("counter", lpaIdCounter + 1);

--- a/scripts/localstack/wait/healthcheck.sh
+++ b/scripts/localstack/wait/healthcheck.sh
@@ -3,8 +3,15 @@
 # SQS
 queues=$(awslocal sqs list-queues)
 echo $queues | grep '"http://sqs.eu-west-1.localhost.localstack.cloud:4566/000000000000/ddc.fifo"' || exit 1
-echo $queues | grep '"http://sqs.eu-west-1.localhost.localstack.cloud:4566/000000000000/notify"' || exit 1
-echo $queues | grep '"http://sqs.eu-west-1.localhost.localstack.cloud:4566/000000000000/notify-dead-letter-queue"' || exit 1
+
+# Secrets Manager
+secrets=$(awslocal secretsmanager list-secrets)
+
+echo $secrets | grep "local/jwt-key" || exit 1
+
+# SSM
+awslocal ssm get-parameter --name=/local/local-credentials | grep "SecureString" || exit 1
+
 
 # S3
 buckets=$(awslocal s3 ls)

--- a/service-app/internal/constants/document_types.go
+++ b/service-app/internal/constants/document_types.go
@@ -55,8 +55,6 @@ var (
 
 	NewCaseDocuments = []string{
 		DocumentTypeEP2PG,
-		DocumentTypeLPA002,
-		DocumentTypeLP0002R,
 		DocumentTypeLP2,
 		DocumentTypeLP1F,
 		DocumentTypeLP1H,

--- a/service-app/xml/Correspondence-valid.xml
+++ b/service-app/xml/Correspondence-valid.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Correspondence xmlns="http://www.w3.org/2001/XMLSchema-instance">
+<Correspondence xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="Correspondence.xsd">
   <SubType>Legal</SubType>
   <CaseNumber>12345</CaseNumber>
   <CaseNumber>67890</CaseNumber>

--- a/service-app/xml/LPA120-valid.xml
+++ b/service-app/xml/LPA120-valid.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<LPA120>
+<LPA120 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="LPA120.xsd">
   <Page1>
     <BURN>DummyBurn1</BURN>
     <PhysicalPage>1</PhysicalPage>

--- a/service-app/xml/LPC-valid.xml
+++ b/service-app/xml/LPC-valid.xml
@@ -1,5 +1,5 @@
 <LPC xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:noNamespaceSchemaLocation="example.xsd">
+     xsi:noNamespaceSchemaLocation="LPC.xsd">
     <Page1>
         <ContinuationSheet1>
             <Attorney>
@@ -48,6 +48,13 @@
 
     <Page2>
         <ContinuationSheet2>
+            <AdditionalInformation>
+                <Notes>true</Notes>
+                <Instructions>true</Instructions>
+                <Preferences>true</Preferences>
+                <ReplacementAttorneys>false</ReplacementAttorneys>
+                <Jointly>false</Jointly>
+            </AdditionalInformation>
             <Donor>
                 <FullName>John Donor</FullName>
                 <Signature>true</Signature>
@@ -60,6 +67,10 @@
 
     <Page3>
         <ContinuationSheet3>
+            <Donor>
+                <FullName>John Donor</FullName>
+            </Donor>
+
             <Signatory>
                 <Signature>true</Signature>
                 <FullName>James Signatory</FullName>
@@ -69,11 +80,23 @@
             <Witnesses>
                 <Signature>true</Signature>
                 <FullName>Witness 1</FullName>
+                <Address>
+                    <Address1>3 Example Road</Address1>
+                    <Address2>Example Town</Address2>
+                    <Address3></Address3>
+                    <Postcode>EX4 MPL</Postcode>
+                </Address>
             </Witnesses>
 
             <Witnesses>
                 <Signature>true</Signature>
                 <FullName>Witness 2</FullName>
+                <Address>
+                    <Address1>3 Example Road</Address1>
+                    <Address2>Example Town</Address2>
+                    <Address3></Address3>
+                    <Postcode>EX4 MPL</Postcode>
+                </Address>
             </Witnesses>
         </ContinuationSheet3>
         <BURN>Valid BURN text</BURN>

--- a/tester/test.sh
+++ b/tester/test.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+HOST=http://localhost:8081
+
+get_token() {
+	auth_reponse=$(curl --location "$HOST/auth/sessions" \
+		--silent \
+		--header 'Content-Type: application/json' \
+		--data-raw '{"user":{"email":"opg_document_and_d@publicguardian.gsi.gov.uk","password":"$2y$10$Xlq5mrdU6ZSh7kU5Yi.vpuCOrWCekNl9BwLcAg5G5bwr22ehTEpEa"}}')
+
+	echo $auth_reponse | jq -r '.authentication_token'
+}
+
+xml_to_set() {
+	type=$1
+	xml=$2
+	caseno=$3
+
+	xml_b64=$(echo $xml | base64)
+
+	echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Set xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"SET.xsd\">
+<Header CaseNo=\"$caseno\" Scanner=\"9\" ScanTime=\"2014-09-26 12:38:53\" ScannerOperator=\"Administrator\" Schedule=\"01-0001253-20160909174150\" />
+<Body>
+<Document Type=\"$type\" Encoding=\"UTF-8\" NoPages=\"1\">
+<XML>$xml_b64</XML>
+<PDF>SUkqAAoAAAAAtBEAAAEDAAEAAAABAAAAAQEDAAEAAAABAAAAAgEDAAEAAAABAAAAAwEDAAEAAAABAAAABgEDAAEAAAABAAAACgEDAAEAAAABAAAADQECAAEAAAAAAAAAEQEEAAEAAAAIAAAAEgEDAAEAAAABAAAAFQEDAAEAAAABAAAAFgEDAAEAAAAAIAAAFwEEAAEAAAABAAAAGgEFAAEAAADcAAAAGwEFAAEAAADkAAAAHAEDAAEAAAABAAAAKAEDAAEAAAACAAAAKQEDAAIAAAAAAAEAAAAAAEgAAAABAAAASAAAAAEAAAA=</PDF>
+</Document>
+</Body>
+</Set>"
+}
+
+upload() {
+	token=$1
+	type=$2
+	file_name=$3
+	include_caseno=$4
+
+	if [[ "$include_caseno" == "Y" ]]; then
+		caseno="7000-1234-1234"
+	else
+		caseno=""
+	fi
+
+	xml=$(cat "./service-app/xml/$file_name")
+	set=$(xml_to_set $type "$xml" "$caseno")
+
+	response=$(curl --location "$HOST/api/ddc" \
+		--silent \
+		--header 'Content-Type: text/xml' \
+		--header "Cookie: membrane=$token" \
+		--data "$set")
+
+	echo $response
+}
+
+check_file() {
+	token=$1
+	type=$2
+	file=$3
+
+	docker compose exec localstack awslocal sqs purge-queue --queue-url=ddc.fifo
+
+	upload_response=$(upload $token $type "$file.xml")
+	upload_success=$(echo $upload_response | jq -r .data.success)
+	if [[ ! $upload_success = "true" ]]; then
+		echo -e "\033[31m$file failed: upload failed with error $(echo $upload_response | jq .data.message)\033[0m"
+		echo -e "\033[31mValidation errors: $(echo $upload_response | jq .data.validationErrors)\033[0m"
+		return 1
+	fi
+
+	upload_uid=$(echo $upload_response | jq -r .data.uid)
+
+	message_body=$(docker compose exec localstack awslocal sqs receive-message --queue-url=ddc.fifo | jq ".Messages[0].Body")
+
+	if [[ ! $message_body =~ "$upload_uid" ]]; then
+		echo -e "\033[31m$file failed: message body doesn't contain $upload_uid (is: $message_body)\033[0m"
+		return 1
+	fi
+
+	echo -e "\033[32m$file passed\033[0m"
+	return 0
+}
+
+check_attachment() {
+	token=$1
+	type=$2
+	file=$3
+
+	upload_response=$(upload $token $type "$file.xml" "Y")
+	upload_success=$(echo $upload_response | jq -r .data.success)
+	if [[ ! $upload_success = "true" ]]; then
+		echo -e "\033[31m$file failed: upload failed with error $(echo $upload_response | jq .data.message)\033[0m"
+		echo -e "\033[31mValidation errors: $(echo $upload_response | jq -r .data.validationErrors)\033[0m"
+		return 1
+	fi
+
+	echo -e "\033[32m$file passed\033[0m"
+	return 0
+}
+
+do_test() {
+	token=$(get_token)
+
+	check_file $token "EP2PG" "EP2PG-valid"
+	check_file $token "LP1F" "LP1F-valid"
+	check_file $token "LP1H" "LP1H-valid"
+	check_file $token "LP2" "LP2-valid"
+
+	check_attachment $token "Correspondence" "Correspondence-valid"
+	check_attachment $token "EPA" "EPA-valid"
+	check_attachment $token "LPA002" "LPA002-valid"
+	check_attachment $token "LPA114" "LPA114-valid"
+	check_attachment $token "LPA117" "LPA117-valid"
+	check_attachment $token "LPA120" "LPA120-valid"
+	check_attachment $token "LPA-PA" "LPA-PA-valid"
+	check_attachment $token "LPA-PW" "LPA-PW-valid"
+	check_attachment $token "LPC" "LPC-valid"
+}
+
+result=$(do_test)
+echo "$result"
+if [[ $result =~ "failed" ]]; then
+	exit 1
+fi


### PR DESCRIPTION
# Purpose

Add an integration test script to be run in the pipeline and check the application works correctly.

Fixes SSM-72 #minor

## Approach

Starts up the application and sends example files to it to check the are correctly parsed.

For files which create cases, it also checks that a message has been added to the SQS queue.

I updated the Sirius mock to generate unique UIDs on each request, which is used to ensure the SQS message relates to the most recent file.

Fixed a few issues with our existing test files.

Removed LPA002 and LPA002R from `NewCaseDocuments`, as they should be supplied alongside LP2s which create the case.

## Learning

Bash really mangled the output of the SQS message, stripping away slashes that made it invalid JSON. I avoided this in the end by doing all the manipulation in one `jq` statement, but it was a sticking point when I had a different approach.

GitHub Actions [doesn't support](https://github.com/actions/runner-images/issues/10451) v1 `docker-compose` so I had to update our scripts to v2 `docker compose`

I needed to update the localstack healthcheck script because it was reporting as healthy too early

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
