### PR TITLE
feat/SSM-86: initial commit consolidating validation test logic

### DIFF
--- a/service-app/internal/factory/document_processor.go
+++ b/service-app/internal/factory/document_processor.go
@@ -69,8 +69,9 @@ func (p *DocumentProcessor) Process(ctx context.Context) (interface{}, error) {
 		return nil, fmt.Errorf("validation setup failed: %w", err)
 	}
 
-	if err := p.validator.Validate(); err != nil {
-		p.logger.Info("Validation failed: %v", nil, err)
+	// Return an error if any validations failed.
+	if messages := p.validator.Validate(); len(messages) > 0 {
+		p.logger.Info("Validation failed: %v", nil, messages)
 	}
 
 	// Sanitize the document

--- a/service-app/internal/parser/corresp_parser/corresp_validator.go
+++ b/service-app/internal/parser/corresp_parser/corresp_validator.go
@@ -36,3 +36,7 @@ func (v *Validator) Validate() error {
 	}
 	return nil
 }
+
+func (v *Validator) GetValidatorErrorMessages() []string {
+	return v.baseValidator.GetValidatorErrorMessages()
+}

--- a/service-app/internal/parser/corresp_parser/corresp_validator.go
+++ b/service-app/internal/parser/corresp_parser/corresp_validator.go
@@ -18,7 +18,7 @@ func NewValidator() *Validator {
 	}
 }
 
-func (v *Validator) Setup(doc interface{}) error {
+func (v *Validator) Setup(doc any) error {
 	if doc == nil {
 		return fmt.Errorf("document is nil")
 	}
@@ -29,14 +29,6 @@ func (v *Validator) Setup(doc interface{}) error {
 	return nil
 }
 
-func (v *Validator) Validate() error {
-	// Return errors if any
-	if messages := v.baseValidator.GetValidatorErrorMessages(); len(messages) > 0 {
-		return fmt.Errorf("failed to validate Correspondence document: %v", messages)
-	}
-	return nil
-}
-
-func (v *Validator) GetValidatorErrorMessages() []string {
+func (v *Validator) Validate() []string {
 	return v.baseValidator.GetValidatorErrorMessages()
 }

--- a/service-app/internal/parser/ep2pg_parser/ep2pg_validator.go
+++ b/service-app/internal/parser/ep2pg_parser/ep2pg_validator.go
@@ -19,7 +19,7 @@ func NewValidator() *Validator {
 	}
 }
 
-func (v *Validator) Setup(doc interface{}) error {
+func (v *Validator) Setup(doc any) error {
 	if doc == nil {
 		return fmt.Errorf("document is nil")
 	}
@@ -30,7 +30,7 @@ func (v *Validator) Setup(doc interface{}) error {
 	return nil
 }
 
-func (v *Validator) Validate() error {
+func (v *Validator) Validate() []string {
 	if v.doc.Page1.Part1.DOB != "" {
 		if _, err := util.ParseDate(v.doc.Page1.Part1.DOB, "02012006"); err != nil {
 			v.baseValidator.AddValidatorErrorMessage("Failed to parse date of birth for Donor: " + err.Error())
@@ -43,13 +43,5 @@ func (v *Validator) Validate() error {
 		}
 	}
 
-	// Return errors if any
-	if messages := v.baseValidator.GetValidatorErrorMessages(); len(messages) > 0 {
-		return fmt.Errorf("failed to validate Correspondence document: %v", messages)
-	}
-	return nil
-}
-
-func (v *Validator) GetValidatorErrorMessages() []string {
 	return v.baseValidator.GetValidatorErrorMessages()
 }

--- a/service-app/internal/parser/ep2pg_parser/ep2pg_validator.go
+++ b/service-app/internal/parser/ep2pg_parser/ep2pg_validator.go
@@ -49,3 +49,7 @@ func (v *Validator) Validate() error {
 	}
 	return nil
 }
+
+func (v *Validator) GetValidatorErrorMessages() []string {
+	return v.baseValidator.GetValidatorErrorMessages()
+}

--- a/service-app/internal/parser/ep2pg_parser/ep2pg_validator_test.go
+++ b/service-app/internal/parser/ep2pg_parser/ep2pg_validator_test.go
@@ -11,11 +11,7 @@ import (
 
 func TestValidXML(t *testing.T) {
 	validator := getValidator(t, "EP2PG-valid.xml")
-	errMessages := validator.Validate()
-	errMessagesLen := len(errMessages)
-	if errMessagesLen > 0 {
-		t.Errorf("Expected no errors but got %d", errMessagesLen)
-	}
+	assert.Len(t, validator.Validate(), 0, "Expected no validation errors")
 }
 
 func TestInvalidXML(t *testing.T) {

--- a/service-app/internal/parser/ep2pg_parser/ep2pg_validator_test.go
+++ b/service-app/internal/parser/ep2pg_parser/ep2pg_validator_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var err error
-
 func TestValidXML(t *testing.T) {
 	validator := getValidator(t, "EP2PG-valid.xml")
-	err = validator.Validate()
-	require.NoError(t, err, "Expected no errors")
+	errMessages := validator.Validate()
+	errMessagesLen := len(errMessages)
+	if errMessagesLen > 0 {
+		t.Errorf("Expected no errors but got %d", errMessagesLen)
+	}
 }
 
 func TestInvalidXML(t *testing.T) {
@@ -23,7 +24,7 @@ func TestInvalidXML(t *testing.T) {
 	expectedErrMsgs := []string{
 		"(?i)^Failed to parse date of birth for Donor:",
 	}
-	parser.TestHelperDocumentValidation(t, fileName, true, expectedErrMsgs, validator)
+	parser.TestHelperDocumentValidation(t, fileName, expectedErrMsgs, validator)
 }
 
 func getValidator(t *testing.T, fileName string) parser.CommonValidator {

--- a/service-app/internal/parser/ep2pg_parser/ep2pg_validator_test.go
+++ b/service-app/internal/parser/ep2pg_parser/ep2pg_validator_test.go
@@ -1,7 +1,6 @@
 package ep2pg_parser
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/ministryofjustice/opg-scanning/internal/parser"
@@ -19,35 +18,12 @@ func TestValidXML(t *testing.T) {
 }
 
 func TestInvalidXML(t *testing.T) {
-	validator := getValidator(t, "EP2PG-invalid-dates.xml")
-	err := validator.Validate()
-	require.Error(t, err, "Expected validation errors due to date ordering but got none")
-
-	messages := validator.(*Validator).baseValidator.GetValidatorErrorMessages()
-
+	fileName := "EP2PG-invalid-dates.xml"
+	validator := getValidator(t, fileName)
 	expectedErrMsgs := []string{
 		"(?i)^Failed to parse date of birth for Donor:",
 	}
-
-	t.Log("Actual messages from validation:")
-	t.Log(messages)
-
-	// Match each expected pattern against actual messages using regex
-	for _, pattern := range expectedErrMsgs {
-		regex, err := regexp.Compile(pattern)
-		require.NoError(t, err, "Failed to compile regex for pattern: %s", pattern)
-
-		// Check if any actual message matches the current regex pattern
-		found := false
-		for _, msg := range messages {
-			if regex.MatchString(msg) {
-				found = true
-				break
-			}
-		}
-
-		require.True(t, found, "Expected error message pattern not found: %s", pattern)
-	}
+	parser.TestHelperDocumentValidation(t, fileName, true, expectedErrMsgs, validator)
 }
 
 func getValidator(t *testing.T, fileName string) parser.CommonValidator {

--- a/service-app/internal/parser/ep2pg_parser/ep2pg_validator_test.go
+++ b/service-app/internal/parser/ep2pg_parser/ep2pg_validator_test.go
@@ -24,7 +24,7 @@ func TestInvalidXML(t *testing.T) {
 	expectedErrMsgs := []string{
 		"(?i)^Failed to parse date of birth for Donor:",
 	}
-	parser.TestHelperDocumentValidation(t, fileName, expectedErrMsgs, validator)
+	parser.DocumentValidationTestHelper(t, fileName, expectedErrMsgs, validator)
 }
 
 func getValidator(t *testing.T, fileName string) parser.CommonValidator {

--- a/service-app/internal/parser/interface.go
+++ b/service-app/internal/parser/interface.go
@@ -2,8 +2,7 @@ package parser
 
 type CommonValidator interface {
 	Setup(doc any) error
-	Validate() error
-	GetValidatorErrorMessages() []string
+	Validate() []string
 }
 
 type CommonSanitizer interface {

--- a/service-app/internal/parser/interface.go
+++ b/service-app/internal/parser/interface.go
@@ -1,12 +1,12 @@
 package parser
 
 type CommonValidator interface {
-	Setup(doc interface{}) error
+	Setup(doc any) error
 	Validate() error
 	GetValidatorErrorMessages() []string
 }
 
 type CommonSanitizer interface {
-	Setup(doc interface{}) error
-	Sanitize() (interface{}, error)
+	Setup(doc any) error
+	Sanitize() (any, error)
 }

--- a/service-app/internal/parser/interface.go
+++ b/service-app/internal/parser/interface.go
@@ -3,6 +3,7 @@ package parser
 type CommonValidator interface {
 	Setup(doc interface{}) error
 	Validate() error
+	GetValidatorErrorMessages() []string
 }
 
 type CommonSanitizer interface {

--- a/service-app/internal/parser/lp1f_parser/lp1f_validator.go
+++ b/service-app/internal/parser/lp1f_parser/lp1f_validator.go
@@ -55,3 +55,7 @@ func (v *Validator) Validate() error {
 	}
 	return nil
 }
+
+func (v *Validator) GetValidatorErrorMessages() []string {
+	return v.baseValidator.GetValidatorErrorMessages()
+}

--- a/service-app/internal/parser/lp1f_parser/lp1f_validator.go
+++ b/service-app/internal/parser/lp1f_parser/lp1f_validator.go
@@ -18,7 +18,7 @@ func NewValidator() *Validator {
 	}
 }
 
-func (v *Validator) Setup(doc interface{}) error {
+func (v *Validator) Setup(doc any) error {
 	if doc == nil {
 		return fmt.Errorf("document is nil")
 	}
@@ -29,7 +29,7 @@ func (v *Validator) Setup(doc interface{}) error {
 	return nil
 }
 
-func (v *Validator) Validate() error {
+func (v *Validator) Validate() []string {
 	// Common witness validations
 	v.baseValidator.WitnessSignatureFullNameAddressValidator("Page10", "Section9")
 
@@ -49,13 +49,5 @@ func (v *Validator) Validate() error {
 		v.baseValidator.ApplicantSignatureValidator(fmt.Sprintf("Page20[%d]", i))
 	}
 
-	// Return errors if any
-	if messages := v.baseValidator.GetValidatorErrorMessages(); len(messages) > 0 {
-		return fmt.Errorf("failed to validate LP1F document: %v", messages)
-	}
-	return nil
-}
-
-func (v *Validator) GetValidatorErrorMessages() []string {
 	return v.baseValidator.GetValidatorErrorMessages()
 }

--- a/service-app/internal/parser/lp1f_parser/lp1f_validator_test.go
+++ b/service-app/internal/parser/lp1f_parser/lp1f_validator_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var err error
-
 func TestValidXML(t *testing.T) {
 	validator := getValidator(t, "LP1F-valid.xml")
-	err = validator.Validate()
-	require.NoError(t, err, "Expected no errors")
+	errMessages := validator.Validate()
+	errMessagesLen := len(errMessages)
+	if errMessagesLen > 0 {
+		t.Errorf("Expected no errors but got %d", errMessagesLen)
+	}
 }
 
 func TestInvalidXML(t *testing.T) {
@@ -23,20 +24,25 @@ func TestInvalidXML(t *testing.T) {
 
 	expectedErrMsgs := []string{
 		"(?i)^Page10 Section9 Witness Signature not set",
+		"(?i)^Page10 Section9 Donor Signature not set",
 		"(?i)^Page10 Section9 Witness Full Name not set",
 		"(?i)^Page10 Section9 Witness Address not valid",
+		"(?i)^Page10 Section9 Donor signature not set or invalid",
+		"(?i)^Page12\\[2\\] Section11 Witness Signature not set",
+		"(?i)^no valid applicant signature/dates found",
 	}
 
-	parser.TestHelperDocumentValidation(t, fileName, true, expectedErrMsgs, validator)
+	parser.TestHelperDocumentValidation(t, fileName, expectedErrMsgs, validator)
 }
 
 func TestInvalidDateOrderXML(t *testing.T) {
 	validator := getValidator(t, "LP1F-invalid-dates.xml")
-	err := validator.Validate()
-	require.Error(t, err, "Expected validation errors due to date ordering but got none")
+	errMessages := validator.Validate()
+	if len(errMessages) == 0 {
+		t.Errorf("Expected validation errors due to date ordering but got none")
+	}
 
-	messages := validator.GetValidatorErrorMessages()
-	found := util.Contains(messages, "all form dates must be before the earliest applicant signature date")
+	found := util.Contains(errMessages, "all form dates must be before the earliest applicant signature date")
 	require.True(t, found, "Expected date ordering validation error not found")
 }
 

--- a/service-app/internal/parser/lp1f_parser/lp1f_validator_test.go
+++ b/service-app/internal/parser/lp1f_parser/lp1f_validator_test.go
@@ -1,7 +1,6 @@
 package lp1f_parser
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/ministryofjustice/opg-scanning/internal/parser"
@@ -19,11 +18,8 @@ func TestValidXML(t *testing.T) {
 }
 
 func TestInvalidXML(t *testing.T) {
-	validator := getValidator(t, "LP1F-invalid.xml")
-	err := validator.Validate()
-	require.Error(t, err, "Expected validation errors due to date ordering but got none")
-
-	messages := validator.(*Validator).baseValidator.GetValidatorErrorMessages()
+	fileName := "LP1F-invalid-dates.xml"
+	validator := getValidator(t, fileName)
 
 	expectedErrMsgs := []string{
 		"(?i)^Page10 Section9 Witness Signature not set",
@@ -35,25 +31,7 @@ func TestInvalidXML(t *testing.T) {
 		"(?i)^no valid applicant signature/dates found",
 	}
 
-	t.Log("Actual messages from validation:")
-	t.Log(messages)
-
-	// Match each expected pattern against actual messages using regex
-	for _, pattern := range expectedErrMsgs {
-		regex, err := regexp.Compile(pattern)
-		require.NoError(t, err, "Failed to compile regex for pattern: %s", pattern)
-
-		// Check if any actual message matches the current regex pattern
-		found := false
-		for _, msg := range messages {
-			if regex.MatchString(msg) {
-				found = true
-				break
-			}
-		}
-
-		require.True(t, found, "Expected error message pattern not found: %s", pattern)
-	}
+	parser.TestHelperDocumentValidation(t, fileName, true, expectedErrMsgs, validator)
 }
 
 func TestInvalidDateOrderXML(t *testing.T) {
@@ -61,7 +39,7 @@ func TestInvalidDateOrderXML(t *testing.T) {
 	err := validator.Validate()
 	require.Error(t, err, "Expected validation errors due to date ordering but got none")
 
-	messages := validator.(*Validator).baseValidator.GetValidatorErrorMessages()
+	messages := validator.GetValidatorErrorMessages()
 	found := util.Contains(messages, "all form dates must be before the earliest applicant signature date")
 	require.True(t, found, "Expected date ordering validation error not found")
 }

--- a/service-app/internal/parser/lp1f_parser/lp1f_validator_test.go
+++ b/service-app/internal/parser/lp1f_parser/lp1f_validator_test.go
@@ -28,22 +28,12 @@ func TestInvalidXML(t *testing.T) {
 		"(?i)^Page10 Section9 Witness Full Name not set",
 		"(?i)^Page10 Section9 Witness Address not valid",
 		"(?i)^Page10 Section9 Donor signature not set or invalid",
-		"(?i)^Page12\\[2\\] Section11 Witness Signature not set",
-		"(?i)^no valid applicant signature/dates found",
+		"(?i)^Page12\\[0] Section11 Witness Signature not set",
+		"(?i)^applicant date is invalid",
+		"(?i)^all form dates must be before the earliest applicant signature date",
 	}
 
-	parser.TestHelperDocumentValidation(t, fileName, expectedErrMsgs, validator)
-}
-
-func TestInvalidDateOrderXML(t *testing.T) {
-	validator := getValidator(t, "LP1F-invalid-dates.xml")
-	errMessages := validator.Validate()
-	if len(errMessages) == 0 {
-		t.Errorf("Expected validation errors due to date ordering but got none")
-	}
-
-	found := util.Contains(errMessages, "all form dates must be before the earliest applicant signature date")
-	require.True(t, found, "Expected date ordering validation error not found")
+	parser.DocumentValidationTestHelper(t, fileName, expectedErrMsgs, validator)
 }
 
 func getValidator(t *testing.T, fileName string) parser.CommonValidator {

--- a/service-app/internal/parser/lp1f_parser/lp1f_validator_test.go
+++ b/service-app/internal/parser/lp1f_parser/lp1f_validator_test.go
@@ -11,11 +11,7 @@ import (
 
 func TestValidXML(t *testing.T) {
 	validator := getValidator(t, "LP1F-valid.xml")
-	errMessages := validator.Validate()
-	errMessagesLen := len(errMessages)
-	if errMessagesLen > 0 {
-		t.Errorf("Expected no errors but got %d", errMessagesLen)
-	}
+	assert.Len(t, validator.Validate(), 0, "Expected no validation errors")
 }
 
 func TestInvalidXML(t *testing.T) {

--- a/service-app/internal/parser/lp1f_parser/lp1f_validator_test.go
+++ b/service-app/internal/parser/lp1f_parser/lp1f_validator_test.go
@@ -23,12 +23,8 @@ func TestInvalidXML(t *testing.T) {
 
 	expectedErrMsgs := []string{
 		"(?i)^Page10 Section9 Witness Signature not set",
-		"(?i)^Page10 Section9 Donor Signature not set",
 		"(?i)^Page10 Section9 Witness Full Name not set",
 		"(?i)^Page10 Section9 Witness Address not valid",
-		"(?i)^Page10 Section9 Donor signature not set or invalid",
-		"(?i)^Page12\\[2\\] Section11 Witness Signature not set",
-		"(?i)^no valid applicant signature/dates found",
 	}
 
 	parser.TestHelperDocumentValidation(t, fileName, true, expectedErrMsgs, validator)

--- a/service-app/internal/parser/lp1h_parser/lp1h_validator.go
+++ b/service-app/internal/parser/lp1h_parser/lp1h_validator.go
@@ -63,6 +63,10 @@ func (v *Validator) Validate() error {
 	return nil
 }
 
+func (v *Validator) GetValidatorErrorMessages() []string {
+	return v.baseValidator.GetValidatorErrorMessages()
+}
+
 // Helper function to extract date from a given section.
 func (v *Validator) extractDate(page, section, path string) (*time.Time, error) {
 	fields, err := v.baseValidator.GetFieldByPath(page, section, path, "DOB")

--- a/service-app/internal/parser/lp1h_parser/lp1h_validator.go
+++ b/service-app/internal/parser/lp1h_parser/lp1h_validator.go
@@ -20,7 +20,7 @@ func NewValidator() *Validator {
 	}
 }
 
-func (v *Validator) Setup(doc interface{}) error {
+func (v *Validator) Setup(doc any) error {
 	if doc == nil {
 		return fmt.Errorf("document is nil")
 	}
@@ -31,7 +31,7 @@ func (v *Validator) Setup(doc interface{}) error {
 	return nil
 }
 
-func (v *Validator) Validate() error {
+func (v *Validator) Validate() []string {
 	// Common witness validations
 	v.baseValidator.WitnessSignatureFullNameAddressValidator("Page10", "Section9")
 
@@ -55,15 +55,6 @@ func (v *Validator) Validate() error {
 		v.baseValidator.AddValidatorErrorMessage(err.Error())
 	}
 
-	// Return errors if any
-	if messages := v.baseValidator.GetValidatorErrorMessages(); len(messages) > 0 {
-		return fmt.Errorf("failed to validate LP1H document: %v", messages)
-	}
-
-	return nil
-}
-
-func (v *Validator) GetValidatorErrorMessages() []string {
 	return v.baseValidator.GetValidatorErrorMessages()
 }
 

--- a/service-app/internal/parser/lp1h_parser/lp1h_validator_test.go
+++ b/service-app/internal/parser/lp1h_parser/lp1h_validator_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var err error
-
 func TestValidXML(t *testing.T) {
 	validator := getValidator(t, "LP1H-valid.xml")
-	err = validator.Validate()
-	require.NoError(t, err, "Expected no errors")
+	errMessages := validator.Validate()
+	errMessagesLen := len(errMessages)
+	if errMessagesLen > 0 {
+		t.Errorf("Expected no errors but got %d", errMessagesLen)
+	}
 }
 
 func getValidator(t *testing.T, fileName string) parser.CommonValidator {

--- a/service-app/internal/parser/lp1h_parser/lp1h_validator_test.go
+++ b/service-app/internal/parser/lp1h_parser/lp1h_validator_test.go
@@ -11,11 +11,7 @@ import (
 
 func TestValidXML(t *testing.T) {
 	validator := getValidator(t, "LP1H-valid.xml")
-	errMessages := validator.Validate()
-	errMessagesLen := len(errMessages)
-	if errMessagesLen > 0 {
-		t.Errorf("Expected no errors but got %d", errMessagesLen)
-	}
+	assert.Len(t, validator.Validate(), 0, "Expected no validation errors")
 }
 
 func getValidator(t *testing.T, fileName string) parser.CommonValidator {

--- a/service-app/internal/parser/lp2_parser/lp2_validator.go
+++ b/service-app/internal/parser/lp2_parser/lp2_validator.go
@@ -19,7 +19,7 @@ func NewValidator() *Validator {
 	}
 }
 
-func (v *Validator) Setup(doc interface{}) error {
+func (v *Validator) Setup(doc any) error {
 	if doc == nil {
 		return fmt.Errorf("document is nil")
 	}
@@ -30,7 +30,7 @@ func (v *Validator) Setup(doc interface{}) error {
 	return nil
 }
 
-func (v *Validator) Validate() error {
+func (v *Validator) Validate() []string {
 	// Validate LP2 Sub-type Selection
 	isPF, err := v.baseValidator.GetFieldByPath("Page1", "Section1", "PropertyFinancialAffairs")
 	if err != nil {
@@ -69,14 +69,5 @@ func (v *Validator) Validate() error {
 		}
 	}
 
-	// Return an error if any validations failed.
-	if messages := v.baseValidator.GetValidatorErrorMessages(); len(messages) > 0 {
-		return fmt.Errorf("failed to validate LPA document: %v", messages)
-	}
-
-	return nil
-}
-
-func (v *Validator) GetValidatorErrorMessages() []string {
 	return v.baseValidator.GetValidatorErrorMessages()
 }

--- a/service-app/internal/parser/lp2_parser/lp2_validator.go
+++ b/service-app/internal/parser/lp2_parser/lp2_validator.go
@@ -50,8 +50,10 @@ func (v *Validator) Validate() error {
 	}
 
 	// Validate Attorney Signature Dates
-	for _, attorney := range v.doc.Page5.Section5.Attorney{
-		if attorney.Date == "" { continue }
+	for _, attorney := range v.doc.Page5.Section5.Attorney {
+		if attorney.Date == "" {
+			continue
+		}
 		if _, err := util.ParseDate(attorney.Date, ""); err != nil {
 			v.baseValidator.AddValidatorErrorMessage("Failed to parse attorney signature date: " + err.Error())
 		}
@@ -59,7 +61,9 @@ func (v *Validator) Validate() error {
 
 	// Validate Attorney Date of Birth
 	for _, attorney := range v.doc.Page2.Section2.Attorney {
-		if attorney.DOB == "" { continue }
+		if attorney.DOB == "" {
+			continue
+		}
 		if _, err := util.ParseDate(attorney.DOB, ""); err != nil {
 			v.baseValidator.AddValidatorErrorMessage("Failed to parse attorney date of birth: " + err.Error())
 		}
@@ -71,4 +75,8 @@ func (v *Validator) Validate() error {
 	}
 
 	return nil
+}
+
+func (v *Validator) GetValidatorErrorMessages() []string {
+	return v.baseValidator.GetValidatorErrorMessages()
 }

--- a/service-app/internal/parser/lp2_parser/lp2_validator_test.go
+++ b/service-app/internal/parser/lp2_parser/lp2_validator_test.go
@@ -11,11 +11,7 @@ import (
 
 func TestValidXML(t *testing.T) {
 	validator := getValidator(t, "LP2-valid.xml")
-	errMessages := validator.Validate()
-	errMessagesLen := len(errMessages)
-	if errMessagesLen > 0 {
-		t.Errorf("Expected no errors but got %d", errMessagesLen)
-	}
+	assert.Len(t, validator.Validate(), 0, "Expected no validation errors")
 }
 
 func TestInvalidXML(t *testing.T) {

--- a/service-app/internal/parser/lp2_parser/lp2_validator_test.go
+++ b/service-app/internal/parser/lp2_parser/lp2_validator_test.go
@@ -22,7 +22,7 @@ func TestInvalidXML(t *testing.T) {
 	fileName := "LP2-invalid-dates.xml"
 	validator := getValidator(t, fileName)
 
-	parser.TestHelperDocumentValidation(t, fileName, []string{
+	parser.DocumentValidationTestHelper(t, fileName, []string{
 		"(?i)^Failed to parse attorney signature date:",
 		"(?i)^Failed to parse attorney date of birth:",
 		"(?i)^Both LPA sub-types are selected",

--- a/service-app/internal/parser/lp2_parser/lp2_validator_test.go
+++ b/service-app/internal/parser/lp2_parser/lp2_validator_test.go
@@ -1,7 +1,6 @@
 package lp2_parser
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/ministryofjustice/opg-scanning/internal/parser"
@@ -19,37 +18,14 @@ func TestValidXML(t *testing.T) {
 }
 
 func TestInvalidXML(t *testing.T) {
-	validator := getValidator(t, "LP2-invalid-dates.xml")
-	err := validator.Validate()
-	require.Error(t, err, "Expected validation errors due to date ordering but got none")
+	fileName := "LP2-invalid-dates.xml"
+	validator := getValidator(t, fileName)
 
-	messages := validator.(*Validator).baseValidator.GetValidatorErrorMessages()
-
-	expectedErrMsgs := []string{
+	parser.TestHelperDocumentValidation(t, fileName, true, []string{
 		"(?i)^Failed to parse attorney signature date:",
 		"(?i)^Failed to parse attorney date of birth:",
 		"(?i)^Both LPA sub-types are selected",
-	}
-
-	t.Log("Actual messages from validation:")
-	t.Log(messages)
-
-	// Match each expected pattern against actual messages using regex
-	for _, pattern := range expectedErrMsgs {
-		regex, err := regexp.Compile(pattern)
-		require.NoError(t, err, "Failed to compile regex for pattern: %s", pattern)
-
-		// Check if any actual message matches the current regex pattern
-		found := false
-		for _, msg := range messages {
-			if regex.MatchString(msg) {
-				found = true
-				break
-			}
-		}
-
-		require.True(t, found, "Expected error message pattern not found: %s", pattern)
-	}
+	}, validator)
 }
 
 func getValidator(t *testing.T, fileName string) parser.CommonValidator {

--- a/service-app/internal/parser/lp2_parser/lp2_validator_test.go
+++ b/service-app/internal/parser/lp2_parser/lp2_validator_test.go
@@ -9,19 +9,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var err error
-
 func TestValidXML(t *testing.T) {
 	validator := getValidator(t, "LP2-valid.xml")
-	err = validator.Validate()
-	require.NoError(t, err, "Expected no errors")
+	errMessages := validator.Validate()
+	errMessagesLen := len(errMessages)
+	if errMessagesLen > 0 {
+		t.Errorf("Expected no errors but got %d", errMessagesLen)
+	}
 }
 
 func TestInvalidXML(t *testing.T) {
 	fileName := "LP2-invalid-dates.xml"
 	validator := getValidator(t, fileName)
 
-	parser.TestHelperDocumentValidation(t, fileName, true, []string{
+	parser.TestHelperDocumentValidation(t, fileName, []string{
 		"(?i)^Failed to parse attorney signature date:",
 		"(?i)^Failed to parse attorney date of birth:",
 		"(?i)^Both LPA sub-types are selected",

--- a/service-app/internal/parser/lpc_parser/lpc_validator.go
+++ b/service-app/internal/parser/lpc_parser/lpc_validator.go
@@ -41,6 +41,10 @@ func (v *Validator) Validate() error {
 	return nil
 }
 
+func (v *Validator) GetValidatorErrorMessages() []string {
+	return v.baseValidator.GetValidatorErrorMessages()
+}
+
 func (v *Validator) validatePage1() {
 	for i, p := range v.doc.Page1 {
 		cs := p.ContinuationSheet1

--- a/service-app/internal/parser/lpc_parser/lpc_validator.go
+++ b/service-app/internal/parser/lpc_parser/lpc_validator.go
@@ -16,7 +16,7 @@ func NewValidator() *Validator {
 	return &Validator{}
 }
 
-func (v *Validator) Setup(doc interface{}) error {
+func (v *Validator) Setup(doc any) error {
 	if doc == nil {
 		return fmt.Errorf("document is nil")
 	}
@@ -30,18 +30,11 @@ func (v *Validator) Setup(doc interface{}) error {
 	return nil
 }
 
-func (v *Validator) Validate() error {
+func (v *Validator) Validate() []string {
 	v.validatePage1()
 	v.validatePage3()
 	v.validatePage4()
 
-	if messages := v.baseValidator.GetValidatorErrorMessages(); len(messages) > 0 {
-		return fmt.Errorf("failed to validate LPC document: %v", messages)
-	}
-	return nil
-}
-
-func (v *Validator) GetValidatorErrorMessages() []string {
 	return v.baseValidator.GetValidatorErrorMessages()
 }
 

--- a/service-app/internal/parser/lpc_parser/lpc_validator_test.go
+++ b/service-app/internal/parser/lpc_parser/lpc_validator_test.go
@@ -11,8 +11,11 @@ import (
 
 func TestValidLPCXML(t *testing.T) {
 	validator := getLPCValidator(t, "LPC-valid.xml")
-	err := validator.Validate()
-	require.NoError(t, err, "Expected no errors for valid LPC XML")
+	errMessages := validator.Validate()
+	errMessagesLen := len(errMessages)
+	if errMessagesLen > 0 {
+		t.Errorf("Expected no errors but got %d", errMessagesLen)
+	}
 }
 
 func TestInvalidLPCXML(t *testing.T) {
@@ -23,7 +26,7 @@ func TestInvalidLPCXML(t *testing.T) {
 		`(?i)Page3\[\d+\] requires exactly 2 Witness blocks, found`,
 		`(?i)Page4\[\d+\] requires exactly 2 AuthorisedPerson blocks, found`,
 	}
-	parser.TestHelperDocumentValidation(t, fileName, true, expectedErrMsgs, validator)
+	parser.TestHelperDocumentValidation(t, fileName, expectedErrMsgs, validator)
 }
 
 func getLPCValidator(t *testing.T, fileName string) parser.CommonValidator {

--- a/service-app/internal/parser/lpc_parser/lpc_validator_test.go
+++ b/service-app/internal/parser/lpc_parser/lpc_validator_test.go
@@ -11,11 +11,7 @@ import (
 
 func TestValidLPCXML(t *testing.T) {
 	validator := getLPCValidator(t, "LPC-valid.xml")
-	errMessages := validator.Validate()
-	errMessagesLen := len(errMessages)
-	if errMessagesLen > 0 {
-		t.Errorf("Expected no errors but got %d", errMessagesLen)
-	}
+	assert.Len(t, validator.Validate(), 0, "Expected no validation errors")
 }
 
 func TestInvalidLPCXML(t *testing.T) {

--- a/service-app/internal/parser/lpc_parser/lpc_validator_test.go
+++ b/service-app/internal/parser/lpc_parser/lpc_validator_test.go
@@ -1,7 +1,6 @@
 package lpc_parser
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/ministryofjustice/opg-scanning/internal/parser"
@@ -17,37 +16,14 @@ func TestValidLPCXML(t *testing.T) {
 }
 
 func TestInvalidLPCXML(t *testing.T) {
-	validator := getLPCValidator(t, "LPC-invalid.xml")
-	err := validator.Validate()
-	require.Error(t, err, "Expected validation errors for invalid LPC XML, but got none")
-
-	messages := validator.(*Validator).baseValidator.GetValidatorErrorMessages()
-
+	fileName := "LPC-invalid.xml"
+	validator := getLPCValidator(t, fileName)
 	expectedErrMsgs := []string{
 		`(?i)Page1\[\d+\] requires exactly 2 Attorney blocks, found`,
 		`(?i)Page3\[\d+\] requires exactly 2 Witness blocks, found`,
 		`(?i)Page4\[\d+\] requires exactly 2 AuthorisedPerson blocks, found`,
 	}
-
-	t.Log("Actual messages from validation:")
-	for _, msg := range messages {
-		t.Log(msg)
-	}
-
-	for _, pattern := range expectedErrMsgs {
-		regex, compErr := regexp.Compile(pattern)
-		require.NoError(t, compErr, "Failed to compile regex for pattern: %s", pattern)
-
-		found := false
-		for _, msg := range messages {
-			if regex.MatchString(msg) {
-				found = true
-				break
-			}
-		}
-
-		require.True(t, found, "Expected error message pattern not found: %s", pattern)
-	}
+	parser.TestHelperDocumentValidation(t, fileName, true, expectedErrMsgs, validator)
 }
 
 func getLPCValidator(t *testing.T, fileName string) parser.CommonValidator {

--- a/service-app/internal/parser/lpc_parser/lpc_validator_test.go
+++ b/service-app/internal/parser/lpc_parser/lpc_validator_test.go
@@ -26,7 +26,7 @@ func TestInvalidLPCXML(t *testing.T) {
 		`(?i)Page3\[\d+\] requires exactly 2 Witness blocks, found`,
 		`(?i)Page4\[\d+\] requires exactly 2 AuthorisedPerson blocks, found`,
 	}
-	parser.TestHelperDocumentValidation(t, fileName, expectedErrMsgs, validator)
+	parser.DocumentValidationTestHelper(t, fileName, expectedErrMsgs, validator)
 }
 
 func getLPCValidator(t *testing.T, fileName string) parser.CommonValidator {

--- a/service-app/internal/parser/validator.go
+++ b/service-app/internal/parser/validator.go
@@ -4,11 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/ministryofjustice/opg-scanning/internal/util"
+	"github.com/stretchr/testify/require"
 )
 
 // Validator is a struct that holds document data and validation error messages
@@ -277,4 +280,44 @@ func (v *BaseValidator) getFieldValues(page, section, field string) (string, err
 	}
 
 	return dateStr, nil
+}
+
+func TestHelperDocumentValidation(
+	t *testing.T,
+	fileName string,
+	expectError bool,
+	expectedPatterns []string,
+	validator CommonValidator,
+) {
+
+	err := validator.Validate()
+
+	if expectError {
+		require.Error(t, err, "Expected validation errors for %s, but got none", fileName)
+
+		// Safely assert that the validator is of the correct type
+		messages := validator.GetValidatorErrorMessages()
+
+		t.Log("Actual messages from validation:")
+		for _, msg := range messages {
+			t.Log(msg)
+		}
+
+		for _, pattern := range expectedPatterns {
+			regex, compErr := regexp.Compile(pattern)
+			require.NoError(t, compErr, "Failed to compile regex for pattern: %s", pattern)
+
+			found := false
+			for _, msg := range messages {
+				if regex.MatchString(msg) {
+					found = true
+					break
+				}
+			}
+
+			require.True(t, found, "Expected error message pattern not found: %s", pattern)
+		}
+	} else {
+		require.NoError(t, err, "Expected no errors for valid document XML")
+	}
 }

--- a/service-app/internal/parser/validator.go
+++ b/service-app/internal/parser/validator.go
@@ -4,16 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"regexp"
 	"strconv"
 	"strings"
-	"testing"
 	"time"
 
-	"slices"
-
 	"github.com/ministryofjustice/opg-scanning/internal/util"
-	"github.com/stretchr/testify/require"
 )
 
 // Validator is a struct that holds document data and validation error messages
@@ -282,25 +277,4 @@ func (v *BaseValidator) getFieldValues(page, section, field string) (string, err
 	}
 
 	return dateStr, nil
-}
-
-func TestHelperDocumentValidation(
-	t *testing.T,
-	fileName string,
-	expectedPatterns []string,
-	validator CommonValidator,
-) {
-	messages := validator.Validate()
-	t.Log("Actual messages from validation:")
-	for _, msg := range messages {
-		t.Log(msg)
-	}
-	for _, pattern := range expectedPatterns {
-		regex, compErr := regexp.Compile(pattern)
-		require.NoError(t, compErr, "Failed to compile regex for pattern: %s", pattern)
-
-		found := slices.ContainsFunc(messages, regex.MatchString)
-
-		require.True(t, found, "Expected error message pattern not found: %s", pattern)
-	}
 }

--- a/service-app/internal/parser/validator.go
+++ b/service-app/internal/parser/validator.go
@@ -287,32 +287,20 @@ func (v *BaseValidator) getFieldValues(page, section, field string) (string, err
 func TestHelperDocumentValidation(
 	t *testing.T,
 	fileName string,
-	expectError bool,
 	expectedPatterns []string,
 	validator CommonValidator,
 ) {
+	messages := validator.Validate()
+	t.Log("Actual messages from validation:")
+	for _, msg := range messages {
+		t.Log(msg)
+	}
+	for _, pattern := range expectedPatterns {
+		regex, compErr := regexp.Compile(pattern)
+		require.NoError(t, compErr, "Failed to compile regex for pattern: %s", pattern)
 
-	err := validator.Validate()
+		found := slices.ContainsFunc(messages, regex.MatchString)
 
-	if expectError {
-		require.Error(t, err, "Expected validation errors for %s, but got none", fileName)
-
-		messages := validator.GetValidatorErrorMessages()
-
-		t.Log("Actual messages from validation:")
-		for _, msg := range messages {
-			t.Log(msg)
-		}
-
-		for _, pattern := range expectedPatterns {
-			regex, compErr := regexp.Compile(pattern)
-			require.NoError(t, compErr, "Failed to compile regex for pattern: %s", pattern)
-
-			found := slices.ContainsFunc(messages, regex.MatchString)
-
-			require.True(t, found, "Expected error message pattern not found: %s", pattern)
-		}
-	} else {
-		require.NoError(t, err, "Expected no errors for valid document XML")
+		require.True(t, found, "Expected error message pattern not found: %s", pattern)
 	}
 }

--- a/service-app/internal/parser/validator.go
+++ b/service-app/internal/parser/validator.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"slices"
+
 	"github.com/ministryofjustice/opg-scanning/internal/util"
 	"github.com/stretchr/testify/require"
 )
@@ -295,7 +297,6 @@ func TestHelperDocumentValidation(
 	if expectError {
 		require.Error(t, err, "Expected validation errors for %s, but got none", fileName)
 
-		// Safely assert that the validator is of the correct type
 		messages := validator.GetValidatorErrorMessages()
 
 		t.Log("Actual messages from validation:")
@@ -307,13 +308,7 @@ func TestHelperDocumentValidation(
 			regex, compErr := regexp.Compile(pattern)
 			require.NoError(t, compErr, "Failed to compile regex for pattern: %s", pattern)
 
-			found := false
-			for _, msg := range messages {
-				if regex.MatchString(msg) {
-					found = true
-					break
-				}
-			}
+			found := slices.ContainsFunc(messages, regex.MatchString)
 
 			require.True(t, found, "Expected error message pattern not found: %s", pattern)
 		}

--- a/service-app/internal/parser/validator_test_helper.go
+++ b/service-app/internal/parser/validator_test_helper.go
@@ -1,0 +1,30 @@
+package parser
+
+import (
+	"regexp"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func DocumentValidationTestHelper(
+	t *testing.T,
+	fileName string,
+	expectedPatterns []string,
+	validator CommonValidator,
+) {
+	messages := validator.Validate()
+	t.Log("Actual messages from validation:")
+	for _, msg := range messages {
+		t.Log(msg)
+	}
+	for _, pattern := range expectedPatterns {
+		regex, compErr := regexp.Compile(pattern)
+		require.NoError(t, compErr, "Failed to compile regex for pattern: %s", pattern)
+
+		found := slices.ContainsFunc(messages, regex.MatchString)
+
+		require.True(t, found, "Expected error message pattern not found: %s", pattern)
+	}
+}

--- a/service-app/xml/LP1F-invalid-dates.xml
+++ b/service-app/xml/LP1F-invalid-dates.xml
@@ -4,7 +4,7 @@
     <Page10>
         <Section9>
             <Donor>
-                <Signature>true</Signature>
+                <Signature></Signature>
                 <Date>2023-12-01</Date> <!-- Later date -->
             </Donor>
         </Section9>
@@ -26,9 +26,11 @@
     <Page12>
         <Section11>
             <Attorney>
-                <Signature>true</Signature>
+                <Signature></Signature>
                 <Date>2023-12-03</Date> <!-- Later date -->
             </Attorney>
+            <Witness>
+            </Witness>
         </Section11>
         <BURN/>
         <PhysicalPage>12</PhysicalPage>
@@ -39,7 +41,7 @@
         <Section15>
             <Applicant>
                 <Signature>true</Signature>
-                <Date>2023-11-01</Date> <!-- Earliest date -->
+                <Date></Date>
             </Applicant>
             <Applicant>
                 <Signature>true</Signature>


### PR DESCRIPTION
# Purpose

Consolidate validation test logic into reusable handler 
Fixes SSM-86

## Approach

Introduce test helper function for all document type validation assertions, `GetValidatorErrorMessages` method added to interface as a result to facilitate the abstraction.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
