### PR TITLE
Require CaseNo on COPORDs

### DIFF
--- a/service-app/internal/constants/document_types.go
+++ b/service-app/internal/constants/document_types.go
@@ -53,12 +53,11 @@ var (
 		DocumentTypeEPA,
 	}
 
-	NewCaseDocuments = []string{
+	NewCaseNumberDocuments = []string{
 		DocumentTypeEP2PG,
 		DocumentTypeLP2,
 		DocumentTypeLP1F,
 		DocumentTypeLP1H,
-		DocumentTypeCOPORD,
 	}
 
 	// these documents should be sent to Sirius to be extracted

--- a/service-app/internal/ingestion/set_validator.go
+++ b/service-app/internal/ingestion/set_validator.go
@@ -43,7 +43,7 @@ func (v *Validator) ValidateSet(parsedSet *types.BaseSet) error {
 	}
 
 	// Validate combinations of instruments and applications
-	newCaseDocuments := v.getEmbeddedDocumentTypes(parsedSet, constants.NewCaseDocuments)
+	newCaseDocuments := v.getEmbeddedDocumentTypes(parsedSet, constants.NewCaseNumberDocuments)
 
 	if len(newCaseDocuments) > 1 {
 		return errors.New("Set cannot contain multiple cases which would create a case")


### PR DESCRIPTION
"NewCaseDocuments" was a bit off as a grouping. We only use it to care about whether the Set should have a CaseNo, which COPORDs should (it should be the court reference number).

Therefore, rename the set variable name to be more accurate and remove COPORD from the set.

#patch
