### PR TITLE
Front-load document type errors

### DIFF
--- a/service-app/internal/api/handler.go
+++ b/service-app/internal/api/handler.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -401,6 +402,12 @@ func (c *IndexController) validateAndSanitizeXML(ctx context.Context, bodyStr st
 }
 
 func (c *IndexController) validateDocument(document types.BaseDocument) error {
+	if !slices.Contains(constants.SupportedDocumentTypes, document.Type) {
+		return Problem{
+			Title: fmt.Sprintf("Document type %s is not supported", document.Type),
+		}
+	}
+
 	decodedXML, err := util.DecodeEmbeddedXML(document.EmbeddedXML)
 	if err != nil {
 		return fmt.Errorf("failed to decode XML data from %s: %w", document.Type, err)

--- a/service-app/internal/api/handler_test.go
+++ b/service-app/internal/api/handler_test.go
@@ -216,6 +216,23 @@ func TestProcessAndPersist_IncludesXMLDeclaration(t *testing.T) {
 	}
 }
 
+func TestValidateDocumentWarnsOnUnsupportedDocumentType(t *testing.T) {
+
+	c := setupController()
+
+	document := types.BaseDocument{
+		Type:        "BadDocumentType",
+		EmbeddedXML: "",
+	}
+
+	err := c.validateDocument(document)
+
+	problem, ok := err.(Problem)
+	assert.True(t, ok)
+
+	assert.Equal(t, "Document type BadDocumentType is not supported", problem.Title)
+}
+
 func TestValidateDocumentHandlesErrorCases(t *testing.T) {
 	testCases := []struct {
 		name string
@@ -225,12 +242,12 @@ func TestValidateDocumentHandlesErrorCases(t *testing.T) {
 		{
 			name: "not XML",
 			XML:  "not XML",
-			err:  "failed to extract schema from TestDocumentType",
+			err:  "failed to extract schema from EPA",
 		},
 		{
 			name: "no schema",
 			XML:  "<my-doc></my-doc>",
-			err:  "failed to extract schema from TestDocumentType",
+			err:  "failed to extract schema from EPA",
 		},
 		{
 			name: "invalid schema",
@@ -240,7 +257,7 @@ func TestValidateDocumentHandlesErrorCases(t *testing.T) {
 		{
 			name: "does not match schema",
 			XML:  `<my-doc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="LP2.xsd"></my-doc>`,
-			err:  "XML for TestDocumentType failed XSD validation",
+			err:  "XML for EPA failed XSD validation",
 		},
 		{
 			name: "ok",
@@ -256,7 +273,7 @@ func TestValidateDocumentHandlesErrorCases(t *testing.T) {
 			encodedXML := base64.StdEncoding.EncodeToString([]byte(tc.XML))
 
 			document := types.BaseDocument{
-				Type:        "TestDocumentType",
+				Type:        "EPA",
 				EmbeddedXML: encodedXML,
 			}
 


### PR DESCRIPTION
# Purpose

If `<Document Type="X">` refers to a type that we don't support, this is only picked up in the internal queue. This means the user gets a 200 response back even though the Set XML isn’t valid.

Fixes SSM-101 #minor

## Approach

Add a check during initial validation of the documents in the set.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
