### PR TITLE
Save Set file to jobsqueue bucket

### DIFF
--- a/service-app/internal/api/handler.go
+++ b/service-app/internal/api/handler.go
@@ -175,6 +175,17 @@ func (c *IndexController) IngestHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Save Set to S3
+	filename, err := c.AwsClient.PersistSetData(reqCtx, []byte(bodyStr))
+	if err != nil {
+		c.respondWithError(reqCtx, w, http.StatusInternalServerError, "Could not persist set to S3", err)
+		return
+	}
+
+	c.logger.InfoWithContext(reqCtx, "Stored Set data", map[string]interface{}{
+		"set_filename": filename,
+	})
+
 	parsedBaseXml, err := c.validateAndSanitizeXML(reqCtx, bodyStr)
 	if err != nil {
 		c.respondWithError(reqCtx, w, http.StatusBadRequest, "Validate and sanitize XML failed", err)

--- a/service-app/internal/auth/middleware_mock.go
+++ b/service-app/internal/auth/middleware_mock.go
@@ -16,6 +16,7 @@ func PrepareMocks(mockConfig *config.Config, logger *logger.Logger) (*mocks.Mock
 	mockAwsClient.On("FetchCredentials", mock.Anything).Maybe().Return(map[string]string{
 		mockConfig.Auth.ApiUsername: hashPassword("password"),
 	}, nil)
+	mockAwsClient.On("PersistSetData", mock.Anything, mock.Anything).Maybe().Return("path/my-set.xml", nil)
 	// Create the HTTP client and middleware
 	mockHttpClient := new(mocks.MockHttpClient)
 	mockHttpClient.On("GetConfig").Return(mockConfig)

--- a/service-app/internal/aws/client_mock.go
+++ b/service-app/internal/aws/client_mock.go
@@ -27,6 +27,11 @@ func (m *MockAwsClient) PersistFormData(ctx context.Context, body io.Reader, doc
 	return args.String(0), args.Error(1)
 }
 
+func (m *MockAwsClient) PersistSetData(ctx context.Context, body []byte) (string, error) {
+	args := m.Called(ctx, body)
+	return args.String(0), args.Error(1)
+}
+
 func (m *MockAwsClient) QueueSetForProcessing(ctx context.Context, scannedCaseResponse *types.ScannedCaseResponse, fileName string) (MessageID *string, err error) {
 	args := m.Called(ctx, scannedCaseResponse, fileName)
 


### PR DESCRIPTION
# Purpose

For easier debugging of issues

Fixes SSM-103 #minor

## Approach

Saves the Set file as soon as possible (after we know it's valid string, before any validation/processing). It will automatically be deleted after 14 days.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
