### PR TITLE
feat/SSM-108: implemented todo so that http timeouts remain consistent.

### DIFF
--- a/service-app/internal/api/handler.go
+++ b/service-app/internal/api/handler.go
@@ -224,7 +224,7 @@ func (c *IndexController) IngestHandler(w http.ResponseWriter, r *http.Request) 
 	for i := range parsedBaseXml.Body.Documents {
 		doc := &parsedBaseXml.Body.Documents[i]
 		// r.Context() carries the enriched logger injected by the middleware.
-		c.Queue.AddToQueue(reqCtx, doc, "xml", func(ctx context.Context, processedDoc any, originalDoc *types.BaseDocument) error {
+		c.Queue.AddToQueue(reqCtx, c.config, doc, "xml", func(ctx context.Context, processedDoc any, originalDoc *types.BaseDocument) error {
 			// Wrap the jobs context with a timeout for callback processing.
 			ctx, cancel := context.WithTimeout(ctx, time.Duration(c.config.HTTP.Timeout)*time.Second)
 			defer cancel()

--- a/service-app/internal/ingestion/job_queue_test.go
+++ b/service-app/internal/ingestion/job_queue_test.go
@@ -45,7 +45,7 @@ func TestJobQueue(t *testing.T) {
 			EmbeddedXML: xml,
 		}
 
-		queue.AddToQueue(ctx, doc, "xml", func(ctx context.Context, processedDocument interface{}, doc *types.BaseDocument) error {
+		queue.AddToQueue(ctx, cfg, doc, "xml", func(ctx context.Context, processedDocument interface{}, doc *types.BaseDocument) error {
 			atomic.AddInt32(&processedJobs, 1)
 			return nil
 		})


### PR DESCRIPTION
# Purpose

Add configurable HTTP timeouts in worker queue

Fixes SSM-108

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
