### PR TITLE
Cheer up gosec

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       - "4566:4566"
       - "4571:4571"
     healthcheck:
-      test: [ "CMD", "bash", "/scripts/wait/healthcheck.sh" ]
+      test: ["CMD", "bash", "/scripts/wait/healthcheck.sh"]
       interval: 5s
       timeout: 10s
       retries: 5
@@ -70,7 +70,7 @@ services:
     volumes:
       - ./docker/sirius:/opt/imposter/config
     healthcheck:
-      test: [ "CMD", "imposter", "list", "-x" ]
+      test: ["CMD", "imposter", "list", "-x"]
       interval: 5s
       timeout: 10s
       retries: 5
@@ -86,10 +86,10 @@ services:
 
   gosec:
     image: securego/gosec:latest
-    working_dir: /app
+    working_dir: /app/service-app
     volumes:
       - .:/app
-    command: -exclude-dir=.gocache -fmt=sarif -out=/app/test-results/gosec.sarif -stdout -verbose=text /app/...
+    command: -exclude-dir=.gocache -fmt=sarif -out=/app/test-results/gosec.sarif -stdout -verbose=text /app/service-app/...
 
   trivy:
     image: aquasec/trivy:latest

--- a/service-app/internal/ingestion/xsd_validator.go
+++ b/service-app/internal/ingestion/xsd_validator.go
@@ -26,7 +26,7 @@ func NewXSDValidator(xsdPath string, xmlContent string) (*XSDValidator, error) {
 	if err != nil {
 		return nil, err
 	}
-	xsdContent, err := os.ReadFile(validPath)
+	xsdContent, err := os.ReadFile(validPath) //#nosec G304 false positive: we check the path above
 	if err != nil {
 		return nil, err
 	}

--- a/service-app/internal/util/common.go
+++ b/service-app/internal/util/common.go
@@ -39,7 +39,7 @@ func LoadXMLFileTesting(t *testing.T, filepath string) []byte {
 	if err != nil {
 		require.FailNow(t, "Invalid file path", err.Error())
 	}
-	data, err := os.ReadFile(validPath)
+	data, err := os.ReadFile(validPath) //#nosec G304 false positive: we check the path above
 	// reading the file.
 	if err != nil {
 		require.FailNow(t, "Failed to read XML file", err.Error())


### PR DESCRIPTION
Mark false positives in code so they don't get flagged. They were previously ignored in GitHub UI, but that doesn't affect the CLI tool.

Only scan `/app/service-app` because it requires being run in the same folder as `go.mod`

#patch