### PR TITLE
Fix golint issues

### DIFF
--- a/service-app/internal/api/handler.go
+++ b/service-app/internal/api/handler.go
@@ -88,7 +88,7 @@ func (c *IndexController) HandleRequests() {
 
 	// Create the route to handle user authentication and issue JWT token
 	http.Handle("/auth/sessions", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c.AuthHandler(r.Context(), w, r)
+		c.AuthHandler(w, r)
 	}))
 
 	// Protect the route with JWT validation (using the authMiddleware)
@@ -108,7 +108,7 @@ func (c *IndexController) HandleRequests() {
 	}
 }
 
-func (c *IndexController) AuthHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+func (c *IndexController) AuthHandler(w http.ResponseWriter, r *http.Request) {
 	// Define response error struct
 	type ErrorResponse struct {
 		Error string `json:"error"`

--- a/service-app/internal/api/handler_test.go
+++ b/service-app/internal/api/handler_test.go
@@ -354,5 +354,9 @@ func jsonUnmarshalReader(reader io.Reader, v any) {
 		panic(err)
 	}
 
-	json.Unmarshal(body, v)
+	err = json.Unmarshal(body, v)
+
+	if err != nil {
+		panic(err)
+	}
 }

--- a/service-app/internal/aws/client_test.go
+++ b/service-app/internal/aws/client_test.go
@@ -144,6 +144,7 @@ func TestAwsQueue_QueueSetForProcessing(t *testing.T) {
 	cfg, err := awsConfig.LoadDefaultConfig(ctx,
 		awsConfig.WithRegion(appConfig.Aws.Region),
 	)
+	assert.NoError(t, err)
 
 	awsClient, err := NewAwsClient(ctx, cfg, appConfig)
 	assert.NoError(t, err, "Failed to create AwsQueue instance")


### PR DESCRIPTION
Ensure errors are captured and tested.

Don't pass `ctx` to AuthHandler: it never refers to the argument and reads it off `r.Context()` internally.

#patch
