### PR TITLE
added XMLParseNoNet to libxml2.ParseString

### DIFF
--- a/service-app/internal/ingestion/xsd_validator.go
+++ b/service-app/internal/ingestion/xsd_validator.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/lestrrat-go/libxml2"
+	"github.com/lestrrat-go/libxml2/parser"
 	"github.com/lestrrat-go/libxml2/xsd"
 	"github.com/ministryofjustice/opg-scanning/internal/util"
 )
@@ -39,7 +40,7 @@ func NewXSDValidator(xsdPath string, xmlContent string) (*XSDValidator, error) {
 }
 
 func (v *XSDValidator) ValidateXsd() error {
-	doc, err := libxml2.ParseString(v.xmlContent)
+	doc, err := libxml2.ParseString(v.xmlContent, parser.XMLParseNoNet)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Purpose

When using libxml2 for XSD validation, we must pass an option NONET to disable external entity processing

Fixes SSM-113

## Checklist

* [x] I have performed a self-review of my own code
