### PR TITLE
feat/SSM-119: ensure correct timeout is propagated.

### DIFF
--- a/service-app/internal/ingestion/job_queue.go
+++ b/service-app/internal/ingestion/job_queue.go
@@ -92,7 +92,7 @@ func (q *JobQueue) StartWorkerPool(ctx context.Context, numWorkers int) {
 
 						if job.onComplete != nil {
 							// Pass the jobs original context to the callback.
-							err := job.onComplete(job.ctx, parsedDoc, job.Data)
+							err := job.onComplete(processCtx, parsedDoc, job.Data)
 							if err != nil {
 								q.recordError(fmt.Errorf("onComplete errors: %v", err.Error()))
 							}

--- a/service-app/internal/ingestion/job_queue.go
+++ b/service-app/internal/ingestion/job_queue.go
@@ -91,7 +91,7 @@ func (q *JobQueue) StartWorkerPool(ctx context.Context, numWorkers int) {
 						}
 
 						if job.onComplete != nil {
-							// Pass the jobs original context to the callback.
+							// Pass HTTP client timeout for processing jobs
 							err := job.onComplete(processCtx, parsedDoc, job.Data)
 							if err != nil {
 								q.recordError(fmt.Errorf("onComplete errors: %v", err.Error()))


### PR DESCRIPTION
# Purpose

The HTTP request within the onComplete callback is executed using the original context `job.ctx`, not the timeout-enforced `processCtx`. This means that when the timeout expires, the HTTP client times out and returns an error, but the request to Sirius doesnt receive the cancellation signal. This mismatch causes the downstream request to continue processing without respecting timeout.

Fixes SSM-119

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
