### PR TITLE
Simplify case creation rules

### DIFF
--- a/service-app/internal/api/processor.go
+++ b/service-app/internal/api/processor.go
@@ -12,14 +12,14 @@ func determineCaseRequest(set *types.BaseSet) (*types.ScannedCaseRequest, error)
 	now := time.Now().Format(time.RFC3339)
 
 	for _, doc := range set.Body.Documents {
-		if util.Contains(constants.LPATypeDocuments, doc.Type) {
+		if util.Contains(constants.CreateLPADocuments, doc.Type) {
 			return &types.ScannedCaseRequest{
 				BatchID:     set.Header.Schedule,
 				CaseType:    "lpa",
 				ReceiptDate: formatScannedDate(set.Header.ScanTime),
 				CreatedDate: now,
 			}, nil
-		} else if util.Contains(constants.EPATypeDocuments, doc.Type) {
+		} else if util.Contains(constants.CreateEPADocuments, doc.Type) {
 			return &types.ScannedCaseRequest{
 				BatchID:     set.Header.Schedule,
 				CaseType:    "epa",

--- a/service-app/internal/api/service_cases_test.go
+++ b/service-app/internal/api/service_cases_test.go
@@ -60,7 +60,7 @@ func buildTestCases() []requestCaseStub {
 		},
 		{
 			name:       "LPA Case without CaseNo",
-			xmlPayload: fmt.Sprintf(withoutCaseNoPayload, "LPA002"),
+			xmlPayload: fmt.Sprintf(withoutCaseNoPayload, "LP1F"),
 			expectedReq: &types.ScannedCaseRequest{
 				BatchID:  "02-0001112-20160909185000",
 				CaseType: "lpa",
@@ -68,13 +68,25 @@ func buildTestCases() []requestCaseStub {
 			expectedErr: false,
 		},
 		{
+			name:       "Other LPA Document with CaseNo",
+			xmlPayload: fmt.Sprintf(withCaseNoPayload, "LPA002"),
+			expectedReq: nil,
+			expectedErr: true,
+		},
+		{
 			name:       "EPA Case without CaseNo",
-			xmlPayload: fmt.Sprintf(withoutCaseNoPayload, "EPA"),
+			xmlPayload: fmt.Sprintf(withoutCaseNoPayload, "EP2PG"),
 			expectedReq: &types.ScannedCaseRequest{
 				BatchID:  "02-0001112-20160909185000",
 				CaseType: "epa",
 			},
 			expectedErr: false,
+		},
+		{
+			name:       "Other EPA Document with CaseNo",
+			xmlPayload: fmt.Sprintf(withCaseNoPayload, "EPA"),
+			expectedReq: nil,
+			expectedErr: true,
 		},
 		{
 			name:        "Invalid Document Type without CaseNo",

--- a/service-app/internal/constants/document_types.go
+++ b/service-app/internal/constants/document_types.go
@@ -53,23 +53,14 @@ var (
 		DocumentTypeFINDOCS,
 	}
 
-	LPATypeDocuments = []string{
-		DocumentTypeLPA002,
+	CreateLPADocuments = []string{
 		DocumentTypeLP1F,
 		DocumentTypeLP1H,
 		DocumentTypeLP2,
 	}
 
-	EPATypeDocuments = []string{
+	CreateEPADocuments = []string{
 		DocumentTypeEP2PG,
-		DocumentTypeEPA,
-	}
-
-	NewCaseNumberDocuments = []string{
-		DocumentTypeEP2PG,
-		DocumentTypeLP2,
-		DocumentTypeLP1F,
-		DocumentTypeLP1H,
 	}
 
 	// these documents should be sent to Sirius to be extracted

--- a/service-app/internal/ingestion/set_validator.go
+++ b/service-app/internal/ingestion/set_validator.go
@@ -43,7 +43,8 @@ func (v *Validator) ValidateSet(parsedSet *types.BaseSet) error {
 	}
 
 	// Validate combinations of instruments and applications
-	newCaseDocuments := v.getEmbeddedDocumentTypes(parsedSet, constants.NewCaseNumberDocuments)
+	createCaseDocumentTypes := append(constants.CreateEPADocuments, constants.CreateLPADocuments...)
+	newCaseDocuments := v.getEmbeddedDocumentTypes(parsedSet, createCaseDocumentTypes)
 
 	if len(newCaseDocuments) > 1 {
 		return errors.New("set cannot contain multiple cases which would create a case")


### PR DESCRIPTION
# Purpose

The scanning app looks at `EPATypeDocuments` and `LPATypeDocuments` when determining whether to create a case, meaning it creates new stubs for EPA and LPA002 documents rather than attaching them to the existing case.

We need to only create cases for LP1F, LP1H, LP2 and EP2PG cases.

Fixes SSM-139 #patch

## Approach

Rather than looking at `LPATypeDocuments`/`EPATypeDocuments` for determining when to create case stubs, and `NewCaseNumberDocuments` when validating the document, centralise the constants into `CreateLPADocuments` and `CreateEPADocuments`.

Also, remove LPA002 and EPA from the lists since they should not create new cases.

## Learning

We should have centralised this logic sooner.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
  * I've fixed and expanded existing tests
