### PR TITLE
Fix JWT processing

### DIFF
--- a/service-app/internal/api/service_cases_test.go
+++ b/service-app/internal/api/service_cases_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/ministryofjustice/opg-scanning/config"
-	"github.com/ministryofjustice/opg-scanning/internal/auth"
+	"github.com/ministryofjustice/opg-scanning/internal/constants"
 	"github.com/ministryofjustice/opg-scanning/internal/httpclient"
 	"github.com/ministryofjustice/opg-scanning/internal/logger"
 	"github.com/ministryofjustice/opg-scanning/internal/types"
@@ -68,8 +68,8 @@ func buildTestCases() []requestCaseStub {
 			expectedErr: false,
 		},
 		{
-			name:       "Other LPA Document with CaseNo",
-			xmlPayload: fmt.Sprintf(withCaseNoPayload, "LPA002"),
+			name:        "Other LPA Document with CaseNo",
+			xmlPayload:  fmt.Sprintf(withCaseNoPayload, "LPA002"),
 			expectedReq: nil,
 			expectedErr: true,
 		},
@@ -83,8 +83,8 @@ func buildTestCases() []requestCaseStub {
 			expectedErr: false,
 		},
 		{
-			name:       "Other EPA Document with CaseNo",
-			xmlPayload: fmt.Sprintf(withCaseNoPayload, "EPA"),
+			name:        "Other EPA Document with CaseNo",
+			xmlPayload:  fmt.Sprintf(withCaseNoPayload, "EPA"),
 			expectedReq: nil,
 			expectedErr: true,
 		},
@@ -154,14 +154,13 @@ func runStubCaseTest(t *testing.T, tt requestCaseStub) {
 			mockConfig.App.SiriusBaseURL = baseURL
 
 			// Mock dependencies
-			_, _, _, tokenGenerator := auth.PrepareMocks(mockConfig, logger)
 			httpClient := httpclient.NewHttpClient(*mockConfig, *logger)
-			httpMiddleware, _ := httpclient.NewMiddleware(httpClient, tokenGenerator)
+			httpMiddleware, _ := httpclient.NewMiddleware(httpClient)
 
 			client := NewClient(httpMiddleware)
 			service := NewService(client, &set)
 
-			ctx := context.Background()
+			ctx := context.WithValue(context.Background(), constants.UserContextKey, "my-token")
 
 			response, err := service.CreateCaseStub(ctx)
 

--- a/service-app/internal/api/service_documents_test.go
+++ b/service-app/internal/api/service_documents_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/ministryofjustice/opg-scanning/config"
-	"github.com/ministryofjustice/opg-scanning/internal/auth"
+	"github.com/ministryofjustice/opg-scanning/internal/constants"
 	"github.com/ministryofjustice/opg-scanning/internal/httpclient"
 	"github.com/ministryofjustice/opg-scanning/internal/logger"
 	"github.com/ministryofjustice/opg-scanning/internal/types"
@@ -73,9 +73,8 @@ func TestAttachDocument_Correspondence(t *testing.T) {
 		mockConfig.App.SiriusBaseURL = baseURL
 		logger := logger.GetLogger(mockConfig)
 
-		_, _, _, tokenGenerator := auth.PrepareMocks(mockConfig, logger)
 		httpClient := httpclient.NewHttpClient(*mockConfig, *logger)
-		httpMiddleware, _ := httpclient.NewMiddleware(httpClient, tokenGenerator)
+		httpMiddleware, _ := httpclient.NewMiddleware(httpClient)
 
 		// Prepare service instance
 		service := &Service{
@@ -96,7 +95,8 @@ func TestAttachDocument_Correspondence(t *testing.T) {
 			UID: "7000-3764-4871",
 		}
 
-		ctx := context.Background()
+		ctx := context.WithValue(context.Background(), constants.UserContextKey, "my-token")
+
 		response, decodedXML, err := service.AttachDocuments(ctx, caseResponse)
 		if err != nil {
 			t.Fatalf("AttachDocuments returned error: %v", err)

--- a/service-app/internal/auth/middleware_test.go
+++ b/service-app/internal/auth/middleware_test.go
@@ -1,75 +1,44 @@
 package auth
 
 import (
-	"context"
-	"sync"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/ministryofjustice/opg-scanning/config"
 	"github.com/ministryofjustice/opg-scanning/internal/logger"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEnsureTokenConcurrency(t *testing.T) {
-	cfg := config.NewConfig()
-	// Set a reasonable JWTExpiration for testiing e.g. 60 seconds
-	cfg.Auth.JWTExpiration = 60
+func testHandler(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("ok"))
+}
 
-	logger := logger.GetLogger(cfg)
+func TestCheckAuthMiddleware(t *testing.T) {
+	mockConfig := config.NewConfig()
+	logger := logger.GetLogger(mockConfig)
+	_, middleware, _, _ := PrepareMocks(mockConfig, logger)
 
-	_, _, mockAwsClient, _ := PrepareMocks(cfg, logger)
-	tokenGenerator := NewJWTTokenGenerator(mockAwsClient, cfg, logger)
+	w := httptest.NewRecorder()
+	handler := middleware.CheckAuthMiddleware(http.HandlerFunc(testHandler))
 
-	var wg sync.WaitGroup
-	numGoroutines := 10
-	tokensChan := make(chan string, numGoroutines)
-	errorsChan := make(chan error, numGoroutines)
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"session-data": "test",
+		"iat":          time.Now().Add(-5 * time.Second).Unix(),
+		"exp":          time.Now().Add(5 * time.Second).Unix(),
+	})
+	tokenString, _ := token.SignedString([]byte("mysupersecrettestkeythatis128bits"))
 
-	// Launch multiple goroutines to call EnsureToken concurrently
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			err := tokenGenerator.EnsureToken(context.Background())
-			if err != nil {
-				errorsChan <- err
-				return
-			}
-			token := tokenGenerator.GetToken()
-			tokensChan <- token
-		}()
-	}
-	wg.Wait()
-	close(errorsChan)
-	close(tokensChan)
+	handler.ServeHTTP(w, &http.Request{
+		Header: map[string][]string{
+			"Cookie": {
+				fmt.Sprintf("membrane=%s", tokenString),
+			},
+		},
+	})
 
-	// Check for any errors from goroutines
-	for err := range errorsChan {
-		t.Errorf("EnsureToken failed: %v", err)
-	}
-
-	// Assert that GetSecretValue was called only once
-	mockAwsClient.AssertNumberOfCalls(t, "GetSecretValue", 1)
-
-	// Collect all tokens and verify they are the same
-	var firstToken string
-	for token := range tokensChan {
-		if firstToken == "" {
-			firstToken = token
-			assert.NotEmpty(t, firstToken, "First token should not be empty")
-		} else {
-			assert.Equal(t, firstToken, token, "All tokens should be identical")
-		}
-	}
-
-	// verify that the token expiry is in the future
-	expiry := tokenGenerator.GetExpiry()
-	assert.True(t, expiry.After(time.Now()), "Token expiry should be in the future")
-
-	// verify that tokenExpiry is around now + JWTExpiration
-	expectedExpiry := time.Now().Add(time.Duration(cfg.Auth.JWTExpiration) * time.Second)
-	assert.WithinDuration(t, expectedExpiry, expiry, 2*time.Second, "Token expiry should be set correctly")
-
-	mockAwsClient.AssertExpectations(t)
+	assert.Equal(t, "ok", w.Body.String())
 }

--- a/service-app/internal/auth/token_test.go
+++ b/service-app/internal/auth/token_test.go
@@ -1,0 +1,125 @@
+package auth
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/ministryofjustice/opg-scanning/config"
+	"github.com/ministryofjustice/opg-scanning/internal/aws"
+	"github.com/ministryofjustice/opg-scanning/internal/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestGenerateToken(t *testing.T) {
+	mockAwsClient := &aws.MockAwsClient{}
+	mockAwsClient.
+		On("GetSecretValue", mock.Anything, "aws::my-secret-arn").
+		Return("my-secret", nil)
+
+	outBuf := bytes.NewBuffer([]byte{})
+	mockLogger := &logger.Logger{SlogLogger: slog.New(slog.NewJSONHandler(outBuf, nil))}
+
+	tg := JWTTokenGenerator{
+		config: &config.Config{
+			Auth: config.Auth{
+				ApiUsername:   "user@host.example",
+				JWTSecretARN:  "aws::my-secret-arn",
+				JWTExpiration: 5,
+			},
+		},
+		awsClient: mockAwsClient,
+		logger:    mockLogger,
+	}
+
+	tokenString, expiry, err := tg.GenerateToken()
+	assert.Nil(t, err)
+
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		return []byte(tg.signingSecret), nil
+	})
+	assert.Nil(t, err)
+
+	tokenExpiry, _ := token.Claims.GetExpirationTime()
+	assert.Equal(t, tokenExpiry.Time, expiry)
+
+	assert.Equal(t, "user@host.example", token.Claims.(jwt.MapClaims)["session-data"])
+
+	assert.Contains(t, outBuf.String(), "Generated new JWT token.")
+}
+
+func TestValidateToken(t *testing.T) {
+	testCases := map[string]struct {
+		claims     jwt.MapClaims
+		expectedOk bool
+	}{
+		"ok": {
+			claims: jwt.MapClaims{
+				"session-data": "test",
+				"iat":          time.Now().Add(-5 * time.Second).Unix(),
+				"exp":          time.Now().Add(5 * time.Second).Unix(),
+			},
+			expectedOk: true,
+		},
+		"empty": {
+			claims:     jwt.MapClaims{},
+			expectedOk: false,
+		},
+		"expired": {
+			claims: jwt.MapClaims{
+				"session-data": "test",
+				"iat":          time.Now().Add(-5 * time.Second).Unix(),
+				"exp":          time.Now().Add(-3 * time.Second).Unix(),
+			},
+			expectedOk: false,
+		},
+		"not-yet-issued": {
+			claims: jwt.MapClaims{
+				"session-data": "test",
+				"iat":          time.Now().Add(3 * time.Second).Unix(),
+				"exp":          time.Now().Add(5 * time.Second).Unix(),
+			},
+			expectedOk: false,
+		},
+		"missing-session-data": {
+			claims: jwt.MapClaims{
+				"iat": time.Now().Add(-5 * time.Second).Unix(),
+				"exp": time.Now().Add(5 * time.Second).Unix(),
+			},
+			expectedOk: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+
+			mockAwsClient := &aws.MockAwsClient{}
+			mockAwsClient.
+				On("GetSecretValue", mock.Anything, "aws::my-secret-arn").
+				Return("my-secret", nil)
+
+			tg := JWTTokenGenerator{
+				config: &config.Config{
+					Auth: config.Auth{
+						JWTSecretARN: "aws::my-secret-arn",
+					},
+				},
+				awsClient: mockAwsClient,
+			}
+
+			token := jwt.NewWithClaims(jwt.SigningMethodHS256, tc.claims)
+			tokenString, _ := token.SignedString([]byte("my-secret"))
+
+			err := tg.ValidateToken(tokenString)
+
+			if tc.expectedOk {
+				assert.Nil(t, err)
+			} else {
+				assert.NotNil(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Purpose

Fixes SSM-141 #minor

## Approach
- Simplify `token.go` to just generate and validate tokens
- Validate tokens in CheckAuthMiddleware
- Generate new token when authenticating user
- Pass token via context to use it in downstream HTTP requests

## Learning

We could do with using mockery for tests rather than the current `prepareMocks` function which is doing too much.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
