### PR TITLE
Don't overwrite documents in jobsqueue bucket

### DIFF
--- a/service-app/internal/api/index_controller.go
+++ b/service-app/internal/api/index_controller.go
@@ -215,9 +215,9 @@ func (c *IndexController) IngestHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Processing qeueue
+	// Processing queue
 	if err := c.ProcessQueue(reqCtx, scannedCaseResponse, parsedBaseXml); err != nil {
-		c.respondWithError(reqCtx, w, http.StatusInternalServerError, err.Error(), err)
+		c.respondWithError(reqCtx, w, http.StatusInternalServerError, "Failed to persist document to Sirius", err)
 		return
 	}
 

--- a/service-app/internal/api/queue_handler.go
+++ b/service-app/internal/api/queue_handler.go
@@ -82,6 +82,8 @@ func (c *IndexController) ProcessQueue(ctx context.Context, scannedCaseResponse 
 				"set_uid":       scannedCaseResponse.UID,
 				"document_type": doc.Type,
 			})
+
+			return err
 		}
 
 		c.logger.InfoWithContext(ctx, "Document added for processing", map[string]any{

--- a/service-app/internal/aws/client.go
+++ b/service-app/internal/aws/client.go
@@ -129,6 +129,7 @@ func (a *AwsClient) PersistFormData(ctx context.Context, body io.Reader, docType
 		Body:                 readerForS3,
 		ServerSideEncryption: types.ServerSideEncryptionAwsKms,
 		SSEKMSKeyId:          &a.config.Aws.JobsQueueBucketKmsKey,
+		IfNoneMatch:          aws.String("*"),
 	}
 
 	// Upload the file to S3
@@ -162,6 +163,7 @@ func (a *AwsClient) PersistSetData(ctx context.Context, body []byte) (string, er
 		Body:                 readerForS3,
 		ServerSideEncryption: types.ServerSideEncryptionAwsKms,
 		SSEKMSKeyId:          &a.config.Aws.JobsQueueBucketKmsKey,
+		IfNoneMatch:          aws.String("*"),
 	}
 
 	_, err := a.S3.PutObject(ctx, input)


### PR DESCRIPTION
If a document already exists with the same key, fail the request so it can be requeued.

Ensure ProcessQueue returns errors and use a friendly message in the response body.

For SSM-143 #minor
