### PR TITLE
Use v7 UUIDs in jobsqueue filenames

### DIFF
--- a/service-app/internal/api/queue_handler.go
+++ b/service-app/internal/api/queue_handler.go
@@ -55,6 +55,10 @@ func (c *IndexController) ProcessQueue(ctx context.Context, scannedCaseResponse 
 				return nil
 			}
 
+			c.logger.InfoWithContext(ctx, "Stored Form data", map[string]any{
+				"filename": fileName,
+			})
+
 			// Queue the document for external processing.
 			messageID, err := c.AwsClient.QueueSetForProcessing(ctx, scannedCaseResponse, fileName)
 			if err != nil {

--- a/service-app/internal/aws/client.go
+++ b/service-app/internal/aws/client.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -15,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/google/uuid"
 	"github.com/ministryofjustice/opg-scanning/config"
 	appTypes "github.com/ministryofjustice/opg-scanning/internal/types"
 	"github.com/ministryofjustice/opg-scanning/internal/util"
@@ -106,9 +106,8 @@ func (a *AwsClient) PersistFormData(ctx context.Context, body io.Reader, docType
 	}
 
 	// Generate the filename using the required format
-	currentTime := time.Now().Format("20060102150405.000000")
-	currentTime = strings.Replace(currentTime, ".", "_", 1)
-	fileName := fmt.Sprintf("FORM_DDC_%s_%s.xml", currentTime, docType)
+	uuid := uuid.Must(uuid.NewV7()).String()
+	fileName := fmt.Sprintf("FORM_DDC_%s_%s.xml", uuid, docType)
 
 	// Check body is valid XML before S3 input
 	bodyBytes, bodyErr := io.ReadAll(body)
@@ -150,9 +149,8 @@ func (a *AwsClient) PersistSetData(ctx context.Context, body []byte) (string, er
 		return "", fmt.Errorf("JOBSQUEUE_BUCKET is not set")
 	}
 
-	currentTime := time.Now().Format("20060102150405.000000")
-	currentTime = strings.Replace(currentTime, ".", "_", 1)
-	fileName := fmt.Sprintf("SET_%s.xml", currentTime)
+	uuid := uuid.Must(uuid.NewV7()).String()
+	fileName := fmt.Sprintf("SET_%s.xml", uuid)
 
 	// Create a new reader from the buffered data
 	readerForS3 := bytes.NewReader(body)

--- a/service-app/internal/aws/client_test.go
+++ b/service-app/internal/aws/client_test.go
@@ -47,7 +47,7 @@ func TestPersistFormData_LocalStack(t *testing.T) {
 	body := bytes.NewReader([]byte("<?xml version=\"1.0\" encoding=\"UTF-8\"?><test>test</test>"))
 	fileName, err := awsClient.PersistFormData(ctx, body, docType)
 	assert.NoError(t, err, "PersistFormData should not return an error")
-	assert.Regexp(t, regexp.MustCompile(`^FORM_DDC_\d{14}_\d{6}_TestDoc.xml$`), fileName)
+	assert.Regexp(t, regexp.MustCompile(`^FORM_DDC_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}_TestDoc.xml$`), fileName)
 
 	// Test PersistFormData invalid
 	docType = "TestDoc"
@@ -87,7 +87,7 @@ func TestPersistSetData(t *testing.T) {
 	body := []byte("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Set>test</Set>")
 	fileName, err := awsClient.PersistSetData(ctx, body)
 	assert.NoError(t, err)
-	assert.Regexp(t, regexp.MustCompile(`^SET_\d{14}_\d{6}.xml$`), fileName)
+	assert.Regexp(t, regexp.MustCompile(`^SET_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}.xml$`), fileName)
 
 	listObjectsOutput, err := awsClient.S3.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
 		Bucket: aws.String(appConfig.Aws.JobsQueueBucket),


### PR DESCRIPTION
# Purpose

Increase the uniqueness of filenames in the jobsqueue bucket to avoid collisions.

Fixes SSM-146 #minor

## Approach

v7 UUIDs increase the uniqueness of the file name to avoid collisions, but maintain a time component so that they can be ordered chronologically and so that the ingestion time could be extracted from the filename.

Also ensured that the filename of form data is explicitly logged.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
