### PR TITLE
Add support for huge XML strings

### DIFF
--- a/service-app/internal/ingestion/xsd_validator.go
+++ b/service-app/internal/ingestion/xsd_validator.go
@@ -40,7 +40,7 @@ func NewXSDValidator(xsdPath string, xmlContent string) (*XSDValidator, error) {
 }
 
 func (v *XSDValidator) ValidateXsd() error {
-	doc, err := libxml2.ParseString(v.xmlContent, parser.XMLParseNoNet)
+	doc, err := libxml2.ParseString(v.xmlContent, parser.XMLParseNoNet+parser.XMLParseHuge)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Purpose

So that we can support very large PDFs, whether that's from high scanning quality or just because they're very long.

Fixes SSM-249 #patch

## Approach

This is a libxml setting, and can be provided as an argument.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
  * I tested locally but haven't added automated tests because it would involve running a very large file into the repo and would just be testing a config option