### PR TITLE
Keep log of scanned documents per batch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - "./localstack-data:/var/lib/localstack/data"
     environment:
       AWS_DEFAULT_REGION: eu-west-1
-      SERVICES: "s3,secretsmanager,sqs,ssm"
+      SERVICES: "dynamodb,s3,secretsmanager,sqs,ssm"
       DEBUG: 1
       DATA_DIR: /var/lib/locals
     ports:

--- a/scripts/localstack/init/localstack_init.sh
+++ b/scripts/localstack/init/localstack_init.sh
@@ -69,3 +69,9 @@ awslocal ssm put-parameter --name "/local/local-credentials" --type "SecureStrin
 # S3
 create_bucket "opg-backoffice-datastore-local"
 create_bucket "opg-backoffice-jobsqueue-local"
+
+# DynamoDB
+awslocal dynamodb create-table --table-name scanning-log-local \
+    --attribute-definitions AttributeName=BatchID,AttributeType=S AttributeName=Timestamp,AttributeType=N \
+    --key-schema AttributeName=BatchID,KeyType=HASH AttributeName=Timestamp,KeyType=RANGE \
+    --provisioned-throughput ReadCapacityUnits=1000,WriteCapacityUnits=1000

--- a/service-app/config/config.go
+++ b/service-app/config/config.go
@@ -29,6 +29,7 @@ type (
 		JobsQueueURL          string `envconfig:"JOBQUEUE_SQS_QUEUE_URL" default:"000000000000/ddc.fifo"`
 		JobsQueueBucket       string `envconfig:"JOBQUEUE_S3_BUCKET_NAME" default:"opg-backoffice-jobsqueue-local"`
 		JobsQueueBucketKmsKey string `envconfig:"JOBQUEUE_S3_ENCRYPTION_KEY" default:"alias/aws/s3"`
+		LogTableName          string `envconfig:"DYNAMODB_LOG_TABLE_NAME" default:"scanning-log-local"`
 		Endpoint              string `envconfig:"AWS_ENDPOINT"`
 		Region                string `envconfig:"AWS_REGION" default:"eu-west-1"`
 	}

--- a/service-app/go.mod
+++ b/service-app/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	go.opentelemetry.io/contrib/detectors/aws/ecs v1.35.0 // indirect
@@ -52,7 +52,7 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.41.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.25.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sns v1.34.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -68,6 +68,8 @@ require (
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.29.14
+	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.19.0
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.79.2
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.35.4
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.38.5

--- a/service-app/go.sum
+++ b/service-app/go.sum
@@ -6,6 +6,8 @@ github.com/aws/aws-sdk-go-v2/config v1.29.14 h1:f+eEi/2cKCg9pqKBoAIwRGzVb70MRKqW
 github.com/aws/aws-sdk-go-v2/config v1.29.14/go.mod h1:wVPHWcIFv3WO89w0rE10gzf17ZYy+UVS1Geq8Iei34g=
 github.com/aws/aws-sdk-go-v2/credentials v1.17.67 h1:9KxtdcIA/5xPNQyZRgUSpYOE6j9Bc4+D7nZua0KGYOM=
 github.com/aws/aws-sdk-go-v2/credentials v1.17.67/go.mod h1:p3C44m+cfnbv763s52gCqrjaqyPikj9Sg47kUVaNZQQ=
+github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.19.0 h1:F3W0YqWZrpCcelbvXMP9LWSTOI620aAq1+8fZ/71TBg=
+github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.19.0/go.mod h1:34X+UzFJwsQfyk5U1hYiCO/gv9ZVL+Hh8w+bJQ6+HbU=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30 h1:x793wxmUWVDhshP8WW2mlnXuFrO4cOd3HLBroh1paFw=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30/go.mod h1:Jpne2tDnYiFascUEs2AWHJL9Yp7A5ZVy3TNyxaAjD6M=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 h1:ZK5jHhnrioRkUNOc+hOgQKlUL5JeC3S6JgLxtQ+Rm0Q=
@@ -16,8 +18,10 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34 h1:ZNTqv4nIdE/DiBfUUfXcLZ/Spcuz+RjeziUtNJackkM=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34/go.mod h1:zf7Vcd1ViW7cPqYWEHLHJkS50X0JS2IKz9Cgaj6ugrs=
-github.com/aws/aws-sdk-go-v2/service/dynamodb v1.41.1 h1:DEys4E5Q2p735j56lteNVyByIBDAlMrO5VIEd9RC0/4=
-github.com/aws/aws-sdk-go-v2/service/dynamodb v1.41.1/go.mod h1:yYaWRnVSPyAmexW5t7G3TcuYoalYfT+xQwzWsvtUQ7M=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.1 h1:YYjNTAyPL0425ECmq6Xm48NSXdT6hDVQmLOJZxyhNTM=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.1/go.mod h1:yYaWRnVSPyAmexW5t7G3TcuYoalYfT+xQwzWsvtUQ7M=
+github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.25.3 h1:GHC1WTF3ZBZy+gvz2qtYB6ttALVx35hlwc4IzOIUY7g=
+github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.25.3/go.mod h1:lUqWdw5/esjPTkITXhN4C66o1ltwDq2qQ12j3SOzhVg=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 h1:eAh2A4b5IzM/lum78bZ590jy36+d/aFLgKF/4Vd1xPE=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3/go.mod h1:0yKJC/kb8sAnmlYa6Zs3QVYqaC8ug2AbnNChv5Ox3uA=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.7.0 h1:lguz0bmOoGzozP9XfRJR1QIayEYo+2vP/No3OfLF0pU=

--- a/service-app/internal/api/index_controller_test.go
+++ b/service-app/internal/api/index_controller_test.go
@@ -68,6 +68,12 @@ func setupController() *IndexController {
 func TestIngestHandler_SetValid(t *testing.T) {
 	controller := setupController()
 
+	if awsClient, ok := controller.AwsClient.(*aws.MockAwsClient); ok {
+		awsClient.
+			On("LogDocument", mock.Anything, "02-0001112-20160909185000", "7000-1234-1234", "LP2").
+			Return(nil)
+	}
+
 	req := httptest.NewRequest(http.MethodPost, "/ingest", bytes.NewBuffer([]byte(xmlPayload)))
 	req.Header.Set("Content-Type", "application/xml")
 	w := httptest.NewRecorder()
@@ -246,6 +252,12 @@ func TestIngestHandler_SiriusErrors(t *testing.T) {
 
 			httpMiddleware, _ := httpclient.NewMiddleware(mockHttpClient)
 			controller.httpMiddleware = httpMiddleware
+
+			if awsClient, ok := controller.AwsClient.(*aws.MockAwsClient); ok {
+				awsClient.
+					On("LogDocument", mock.Anything, "02-0001112-20160909185000", "700012341234", "Correspondence").
+					Return(nil)
+			}
 
 			req := httptest.NewRequest(http.MethodPost, "/ingest", bytes.NewBuffer([]byte(xmlPayloadCorrespondence)))
 			req.Header.Set("Content-Type", "application/xml")

--- a/service-app/internal/aws/client_mock.go
+++ b/service-app/internal/aws/client_mock.go
@@ -39,3 +39,8 @@ func (m *MockAwsClient) QueueSetForProcessing(ctx context.Context, scannedCaseRe
 
 	return &messageId, args.Error(1)
 }
+
+func (m *MockAwsClient) LogDocument(ctx context.Context, batchID string, caseUid string, documentType string) error {
+	args := m.Called(ctx, batchID, caseUid, documentType)
+	return args.Error(0)
+}


### PR DESCRIPTION
So we can more easily reference what files came through in a particular batch and compare with what we're expecting from the supplier.

Fixes SSM-145 #minor
