### PR TITLE
Reduce duplicate log messages

### DIFF
--- a/service-app/internal/api/queue_handler.go
+++ b/service-app/internal/api/queue_handler.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 
 	"github.com/ministryofjustice/opg-scanning/internal/constants"
@@ -27,13 +28,13 @@ func (c *IndexController) processQueue(ctx context.Context, scannedCaseResponse 
 
 			attchResp, decodedXML, docErr := service.AttachDocuments(ctx, scannedCaseResponse)
 			if docErr != nil {
-				return docErr
+				return fmt.Errorf("failed to attach document: %w", docErr)
 			}
 
 			// Persist the processed document.
 			fileName, persistErr := c.processAndPersist(ctx, decodedXML, originalDoc)
 			if persistErr != nil {
-				return persistErr
+				return fmt.Errorf("failed to persist document: %w", persistErr)
 			}
 
 			// If not a Sirius extraction document, skip external job processing.

--- a/service-app/internal/ingestion/job_queue.go
+++ b/service-app/internal/ingestion/job_queue.go
@@ -62,9 +62,7 @@ func (q *JobQueue) AddToQueueSequentially(ctx context.Context, cfg *config.Confi
 	}
 
 	if onComplete != nil {
-		if err = onComplete(processCtx, parsedDoc, data); err != nil {
-			return fmt.Errorf("onComplete error: %w", err)
-		}
+		return onComplete(processCtx, parsedDoc, data)
 	}
 
 	return nil


### PR DESCRIPTION
## Purpose

Eensures 4xx responses from Sirius don't get logged at ERROR level, and prevent duplicate log entries for other errors.

Fixes SSM-153 #patch

## Approach

- Stop wrapping errors with an unnecessary `onComplete` prefix
- Stop logging errors coming back from `onComplete`
- Stop logging `sirius.Error` errors at `ERROR` level: they are not a problem with the service and don't require action

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
  * N/A
* [ ] I have added tests to prove my work
