### PR TITLE
Handle 413 responses form Sirius better

### DIFF
--- a/service-app/internal/api/index_controller.go
+++ b/service-app/internal/api/index_controller.go
@@ -195,11 +195,7 @@ func (c *IndexController) ingestHandler(w http.ResponseWriter, r *http.Request) 
 	// Processing queue
 	if err := c.processQueue(reqCtx, scannedCaseResponse, parsedBaseXml); err != nil {
 		statusCode, message := getPublicError(err, scannedCaseResponse.UID)
-		if message != "" {
-			c.respondWithError(reqCtx, w, statusCode, message, err)
-		} else {
-			c.respondWithError(reqCtx, w, http.StatusInternalServerError, "Failed to persist document to Sirius", err)
-		}
+		c.respondWithError(reqCtx, w, statusCode, message, err)
 
 		return
 	}
@@ -233,7 +229,7 @@ func (c *IndexController) ingestHandler(w http.ResponseWriter, r *http.Request) 
 func getPublicError(err error, uid string) (int, string) {
 	var clientError sirius.Error
 	if !errors.As(err, &clientError) {
-		return 500, ""
+		return 500, "Failed to persist document to Sirius"
 	}
 
 	if clientError.StatusCode == 404 {
@@ -251,7 +247,7 @@ func getPublicError(err error, uid string) (int, string) {
 		return 413, "Request content too large: the XML document exceeds the maximum allowed size"
 	}
 
-	return 500, ""
+	return 500, "Failed to persist document to Sirius"
 }
 
 func (c *IndexController) respondWithError(ctx context.Context, w http.ResponseWriter, statusCode int, message string, err error) {

--- a/service-app/internal/api/index_controller_test.go
+++ b/service-app/internal/api/index_controller_test.go
@@ -213,7 +213,7 @@ func TestIngestHandler_SiriusErrors(t *testing.T) {
 	</Set>`
 
 	testCases := map[string]struct {
-		siriusError        sirius.Error
+		siriusError        error
 		expectedStatusCode int
 		expectedMessage    string
 	}{
@@ -243,10 +243,22 @@ func TestIngestHandler_SiriusErrors(t *testing.T) {
 			expectedStatusCode: 500,
 			expectedMessage:    "Failed to persist document to Sirius",
 		},
+		"413": {
+			siriusError: sirius.Error{
+				StatusCode: 413,
+			},
+			expectedStatusCode: 413,
+			expectedMessage:    "Request content too large: the XML document exceeds the maximum allowed size",
+		},
 		"500": {
 			siriusError: sirius.Error{
 				StatusCode: 500,
 			},
+			expectedStatusCode: 500,
+			expectedMessage:    "Failed to persist document to Sirius",
+		},
+		"other error": {
+			siriusError: errors.New("a generic error"),
 			expectedStatusCode: 500,
 			expectedMessage:    "Failed to persist document to Sirius",
 		},

--- a/service-app/internal/sirius/client.go
+++ b/service-app/internal/sirius/client.go
@@ -127,7 +127,7 @@ func (c *Client) do(req *http.Request, v any) error {
 		return fmt.Errorf("read response body: %w", err)
 	}
 
-	// Handle non-2xx responses
+	// Handle 4xx responses
 	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
 		errOut := Error{
 			StatusCode: resp.StatusCode,
@@ -146,6 +146,7 @@ func (c *Client) do(req *http.Request, v any) error {
 		return errOut
 	}
 
+	// Handle non-2xx responses
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("unexpected status code: %d - Response: %s", resp.StatusCode, string(body))
 	}


### PR DESCRIPTION
# Purpose

If Sirius returns a 413 error, return that status code to the client and give them a clearer error message.

Fixes SSM-154 #patch

## Approach

Expand existing pattern for other 4xx errors

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
